### PR TITLE
Double-click on JAR doesn't launch the application #32

### DIFF
--- a/wix/Lang/OpenJDK.Base.de-de.wxl
+++ b/wix/Lang/OpenJDK.Base.de-de.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Als JRE_HOME-Umgebungsvariable verwenden.</String>
 	<String Id="FeatureSourceTitle">Quellcode</String>
 	<String Id="FeatureSourceDescription">Quellcode für Klassen, welche die öffentliche API von Java enthalten.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.en-us.wxl
+++ b/wix/Lang/OpenJDK.Base.en-us.wxl
@@ -15,4 +15,6 @@
 	<String Id="FeatureJreHomeDescription">Set JRE_HOME environment variable.</String>
 	<String Id="FeatureSourceTitle">Source Code</String>
 	<String Id="FeatureSourceDescription">Source code for classes that comprise the public API of Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.es-es.wxl
+++ b/wix/Lang/OpenJDK.Base.es-es.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Establecer la variable de entorno JRE_HOME.</String>
 	<String Id="FeatureSourceTitle">Código fuente</String>
 	<String Id="FeatureSourceDescription">Código fuente de las clases que componen la API pública de Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.fr-fr.wxl
+++ b/wix/Lang/OpenJDK.Base.fr-fr.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Définir la variable d'environnement JRE_HOME.</String>
 	<String Id="FeatureSourceTitle">Code source</String>
 	<String Id="FeatureSourceDescription">Code source des classes qui composent l'API publique de Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associer les .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associer les fichiers .jar avec AdoptOpenJDK pour execution par double-click</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.ja-jp.wxl
+++ b/wix/Lang/OpenJDK.Base.ja-jp.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Set JRE_HOME environment variable.</String>
 	<String Id="FeatureSourceTitle">Source Code</String>
 	<String Id="FeatureSourceDescription">Source code for classes that comprise the public API of Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.zh-cn.wxl
+++ b/wix/Lang/OpenJDK.Base.zh-cn.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Set JRE_HOME environment variable.</String>
 	<String Id="FeatureSourceTitle">Source Code</String>
 	<String Id="FeatureSourceDescription">Source code for classes that comprise the public API of Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Lang/OpenJDK.Base.zh-tw.wxl
+++ b/wix/Lang/OpenJDK.Base.zh-tw.wxl
@@ -14,4 +14,6 @@
 	<String Id="FeatureJreHomeDescription">Set JRE_HOME environment variable.</String>
 	<String Id="FeatureSourceTitle">Source Code</String>
 	<String Id="FeatureSourceDescription">Source code for classes that comprise the public API of Java.</String>
+	<String Id="FeatureJarFileRunWithTitle">Associate .jar</String>
+	<String Id="FeatureJarFileRunWithDescription">Associate .jar files to run with AdoptOpenJDK</String>
 </WixLocalization>

--- a/wix/Main.hotspot.wxs
+++ b/wix/Main.hotspot.wxs
@@ -85,6 +85,21 @@
           <Environment Id="JAVA_HOME" Name="JAVA_HOME" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
         </Component>
       <?endif?>
+      <!-- Add jar launch by double click -->
+      <Component Id="SetJarFileRunWith" Guid="*">
+        <!--
+        https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
+            If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
+            If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
+         
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jar\OpenWithProgids
+        is automatically created by Windows when running jar file for the first time
+        -->
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\.jar" Type="string" Value="AdoptOpenJDK.jarfile" KeyPath="yes" />
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\.jar" Type="string" Name="Content Type" Value="application/jar" KeyPath="no" />
+        
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\AdoptOpenJDK.jarfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaw.exe&quot; -jar &quot;%1&quot; %*" KeyPath="no" />
+      </Component>
     </DirectoryRef>
 
     <!-- List of features to install -->
@@ -94,6 +109,9 @@
 
 			<Feature Id="FeatureEnvironment" Level="1" Title="!(loc.FeatureEnvironmentTitle)" Description="!(loc.FeatureEnvironmentDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
 				<ComponentRef Id="AddToEnvironmentPath" />
+			</Feature>
+			<Feature Id="FeatureJarFileRunWith" Level="1" Title="!(loc.FeatureJarFileRunWithTitle)" Description="!(loc.FeatureJarFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
+				<ComponentRef Id="SetJarFileRunWith" />
 			</Feature>
       <?if $(env.PRODUCT_CATEGORY)="jre"?>
         <Feature Id="FeatureJreHome" Level="2" Title="!(loc.FeatureJreHomeTitle)" Description="!(loc.FeatureJreHomeDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">

--- a/wix/Main.openj9.wxs
+++ b/wix/Main.openj9.wxs
@@ -85,6 +85,21 @@
           <Environment Id="JAVA_HOME" Name="JAVA_HOME" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
         </Component>
       <?endif?>
+      <!-- Add jar launch by double click -->
+      <Component Id="SetJarFileRunWith" Guid="*">
+        <!--
+        https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
+            If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
+            If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
+         
+        HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jar\OpenWithProgids
+        is automatically created by Windows when running jar file for the first time
+        -->
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\.jar" Type="string" Value="AdoptOpenJDK.jarfile" KeyPath="yes" />
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\.jar" Type="string" Name="Content Type" Value="application/jar" KeyPath="no" />
+        
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\AdoptOpenJDK.jarfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaw.exe&quot; -jar &quot;%1&quot; %*" KeyPath="no" />
+      </Component>
     </DirectoryRef>
 
     <!-- List of features to install -->
@@ -94,6 +109,9 @@
 
 			<Feature Id="FeatureEnvironment" Level="1" Title="!(loc.FeatureEnvironmentTitle)" Description="!(loc.FeatureEnvironmentDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
 				<ComponentRef Id="AddToEnvironmentPath" />
+			</Feature>
+			<Feature Id="FeatureJarFileRunWith" Level="1" Title="!(loc.FeatureJarFileRunWithTitle)" Description="!(loc.FeatureJarFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
+				<ComponentRef Id="SetJarFileRunWith" />
 			</Feature>
       <?if $(env.PRODUCT_CATEGORY)="jre"?>
         <Feature Id="FeatureJreHome" Level="2" Title="!(loc.FeatureJreHomeTitle)" Description="!(loc.FeatureJreHomeDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">

--- a/wix/README.md
+++ b/wix/README.md
@@ -40,3 +40,21 @@
       If Java Runtime Environment need to be build with Eclipse OpenJ9 only.
 
 5. Deploy via Active Directory GPO.
+
+
+5a. Installation optional parameters:
+	INSTALLLEVEL
+		1 = (Add to PATH + Associate jar)
+		2 = (Add to PATH + Associate jar) + define JAVA_HOME
+		usage sample: 
+		msiexec /i OpenJDK8-jdk_xxx.msi INSTALLLEVEL=1
+		msiexec /i OpenJDK8-jdk_xxx.msi INSTALLLEVEL=2
+		
+	Features available:
+		FeatureEnvironment ( PATH )
+		FeatureJavaHome (JAVA_HOME)
+		FeatureJarFileRunWith (associate .jar)
+		
+		usage sample:
+		msiexec /i OpenJDK8-jdk_xxx.msi ADDLOCAL=FeatureJavaHome,FeatureJarFileRunWith
+		

--- a/wix/SourceDir/CreateSourceFolder.OpenJDK11.ps1
+++ b/wix/SourceDir/CreateSourceFolder.OpenJDK11.ps1
@@ -1,3 +1,4 @@
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; 
 $urls = @(
   'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jdk_x64_windows_hotspot_11_28.zip',
   'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11%2B28/OpenJDK11-jdk_x64_windows_openj9_11_28.zip',

--- a/wix/SourceDir/CreateSourceFolder.OpenJDK8.ps1
+++ b/wix/SourceDir/CreateSourceFolder.OpenJDK8.ps1
@@ -1,3 +1,4 @@
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; 
 $urls = @(
   'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u181-b13/OpenJDK8U-jdk_x64_windows_hotspot_8u181b13.zip',
   'https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u181-b13/OpenJDK8U-jre_x64_windows_hotspot_8u181b13.zip',


### PR DESCRIPTION
Adding registry keys to map .jar extension with javaw.exe -jar

closes: https://github.com/AdoptOpenJDK/openjdk-installer/issues/32