### PR TITLE
add jre sourceDir

### DIFF
--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -53,7 +53,7 @@ IF NOT "%PRODUCT_CATEGORY%" == "jre" (
 
 
 IF "%SKIP_MSI_VALIDATION%" == "true" (
-	SET "MSI_VALIDATION_OPTION= -sval " 
+	SET "MSI_VALIDATION_OPTION= -sval "
 )
 
 REM Configure available SDK version:
@@ -95,7 +95,9 @@ FOR %%A IN (%ARCH%) DO (
     ) ELSE (
         REM NEW REPRO_DIR format for JDK version 11 12 etc ..
         SET REPRO_DIR=.\SourceDir\!PRODUCT_SKU!!PRODUCT_MAJOR_VERSION!\!PACKAGE_TYPE!\!FOLDER_PLATFORM!\jdk-%PRODUCT_MAJOR_VERSION%+%PRODUCT_PATCH_VERSION%
-
+	IF !PRODUCT_CATEGORY! == jre (
+	    SET REPRO_DIR=!REPRO_DIR!-!PRODUCT_CATEGORY!
+	)
         IF NOT EXIST "!REPRO_DIR!" (
             ECHO First !REPRO_DIR! not exists
             SET REPRO_DIR=.\SourceDir\!PRODUCT_SKU!!PRODUCT_MAJOR_VERSION!\!PACKAGE_TYPE!\!FOLDER_PLATFORM!\jdk-%PRODUCT_MAJOR_VERSION%.%PRODUCT_MINOR_VERSION%.%PRODUCT_MAINTENANCE_VERSION%+%PRODUCT_PATCH_VERSION%
@@ -161,7 +163,7 @@ FOR %%A IN (%ARCH%) DO (
 	)
 
     REM Build without extra Source Code feature
-    
+
 	ECHO HEAT
 	@ECHO ON
     "!WIX!bin\heat.exe" dir "!REPRO_DIR!" -out Files-!OUTPUT_BASE_FILENAME!.wxs -gg -sfrag -scom -sreg -srd -ke -cg "AppFiles" -var var.ProductMajorVersion -var var.ProductMinorVersion -var var.ProductMaintenanceVersion -var var.ProductPatchVersion -var var.ReproDir -dr INSTALLDIR -platform !PLATFORM!
@@ -170,7 +172,7 @@ FOR %%A IN (%ARCH%) DO (
 	    GOTO FAILED
 	)
 	@ECHO OFF
-	
+
 	ECHO CANDLE
 	@ECHO ON
     "!WIX!bin\candle.exe" -arch !PLATFORM! Main-!OUTPUT_BASE_FILENAME!.wxs Files-!OUTPUT_BASE_FILENAME!.wxs -ext WixUIExtension -ext WixUtilExtension -dProductSku="!PRODUCT_SKU!" -dProductMajorVersion="!PRODUCT_MAJOR_VERSION!" -dProductMinorVersion="!PRODUCT_MINOR_VERSION!" -dProductMaintenanceVersion="!PRODUCT_MAINTENANCE_VERSION!" -dProductPatchVersion="!PRODUCT_PATCH_VERSION!" -dProductId="!PRODUCT_ID!" -dProductUpgradeCode="!PRODUCT_UPGRADE_CODE!" -dReproDir="!REPRO_DIR!" -dSetupResourcesDir="!SETUP_RESOURCES_DIR!" -dCulture="!CULTURE!" -dJVM="!PACKAGE_TYPE!"
@@ -179,7 +181,7 @@ FOR %%A IN (%ARCH%) DO (
 	    GOTO FAILED
 	)
 	@ECHO OFF
-	
+
 	ECHO LIGHT
 	@ECHO ON
     "!WIX!bin\light.exe" Main-!OUTPUT_BASE_FILENAME!.wixobj Files-!OUTPUT_BASE_FILENAME!.wixobj !MSI_VALIDATION_OPTION! -cc !CACHE_FOLDER! -ext WixUIExtension -ext WixUtilExtension -spdb -out "ReleaseDir\!OUTPUT_BASE_FILENAME!.msi" -loc "Lang\!PRODUCT_SKU!.Base.!CULTURE!.wxl" -loc "Lang\!PRODUCT_SKU!.!PACKAGE_TYPE!.!CULTURE!.wxl" -cultures:!CULTURE!
@@ -205,7 +207,7 @@ FOR %%A IN (%ARCH%) DO (
 	    GOTO FAILED
 	)
 
-	REM For temporarily disable the smoke test - use OPTION SKIP_MSI_VALIDATION=true 
+	REM For temporarily disable the smoke test - use OPTION SKIP_MSI_VALIDATION=true
 	REM To validate MSI only once at the end
 	IF NOT "%SKIP_MSI_VALIDATION%" == "true" (
 		ECHO SMOKE
@@ -236,7 +238,7 @@ FOR %%A IN (%ARCH%) DO (
     ) ELSE (
         ECHO Ignoring signing step : not certificate configured
     )
-    
+
 
     REM Remove files we do not need any longer.
     DEL "Files-!OUTPUT_BASE_FILENAME!.wxs"


### PR DESCRIPTION
Currently on jdk11 and 12 we are bundling the JDK into the JRE installer. This is a bug.