### PR TITLE
Only depend on libfreetype6 instead of libfreetype6-dev.

### DIFF
--- a/linux/deb/config/jdk-10-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-10-hotspot/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-10-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-10-hotspot/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-10-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-10-openj9/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-10-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-10-openj9/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-12-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-12-hotspot/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-12-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-12-hotspot/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-12-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-12-openj9/dependencies.txt
@@ -1,6 +1,5 @@
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-12-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-12-openj9/dependencies.txt
@@ -1,6 +1,6 @@
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libssl1.1
 libx11-6
 libxext6

--- a/linux/deb/config/jdk-8-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libssl1.1
 libx11-6
 libxext6

--- a/linux/deb/config/jdk-9-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-9-hotspot/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-9-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-9-hotspot/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-9-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-9-openj9/dependencies.txt
@@ -2,7 +2,7 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6-dev
+libfreetype6
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-9-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-9-openj9/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates-java
 java-common
 libasound2
 libc6
-libfreetype6
 libx11-6
 libxext6
 libxi6


### PR DESCRIPTION
libfreetype6-dev is a development dependency which would only be used, if AdoptOpenJDK compiles something to link to it either during or after package installation. But this does not seem to be the case.