### PR TITLE
Make RPM package name match the Debian’s name

### DIFF
--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -2,7 +2,7 @@ import net.adoptopenjdk.installer.BuildRpmPackage
 import net.adoptopenjdk.installer.UploadRpmPackage
 
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
-    packageName = "java-${jdkMajorVersion}-adoptopenjdk-${pkgMetadata.vm}"
+    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}"
     packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture.rpmQualifier()
@@ -23,7 +23,7 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
 }
 
 tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
-    packageName = "java-${jdkMajorVersion}-adoptopenjdk-${pkgMetadata.vm}"
+    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}"
     packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture.rpmQualifier()


### PR DESCRIPTION
The new naming scheme for RPMs is `adoptopenjdk-<version>-<vm>`.

Output from CentOS 7 with JDK 12:

```
[root@6bf4b02f1c66 /]# yum search adoptopenjdk
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: pkg.adfinis-sygroup.ch
 * extras: pkg.adfinis-sygroup.ch
 * updates: pkg.adfinis-sygroup.ch
============================================== N/S matched: adoptopenjdk ===============================================
adoptopenjdk-12-hotspot.x86_64 : OpenJDK Development Kit 12 (JDK) by AdoptOpenJDK

  Name and summary matches only, use "search all" for everything.
[root@6bf4b02f1c66 /]# yum info adoptopenjdk-12-hotspot
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: pkg.adfinis-sygroup.ch
 * extras: pkg.adfinis-sygroup.ch
 * updates: pkg.adfinis-sygroup.ch
Installed Packages
Name        : adoptopenjdk-12-hotspot
Arch        : x86_64
Version     : 12.0.1+12
Release     : 1
Size        : 335 M
Repo        : installed
Summary     : OpenJDK Development Kit 12 (JDK) by AdoptOpenJDK
URL         : https://adoptopenjdk.net/
License     : GPL-2.0+CE
Description : OpenJDK Development Kit 12 (JDK) by AdoptOpenJDK

[root@6bf4b02f1c66 /]# ls -l /usr/lib/jvm
total 4
drwxr-xr-x 10 root root 4096 Apr 30 12:16 adoptopenjdk-12-hotspot
```