### PR TITLE
Package JREs for Linux

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -23,7 +23,7 @@ Note: Linux packages can be created on any Linux distribution and macOS and on a
 
 ## Packaging
 
-It is possible to simultaneously build Debian and RPM packages by using `./gradlew build` and specifying all properties (`-P`) that required by all package formats.
+It is possible to simultaneously build Debian and RPM packages by using `./gradlew build` and specifying all properties (`-P`) that are required by the various package formats.
 
 ### Deb packages
 
@@ -101,7 +101,7 @@ Example:
 | JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
 | JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
 
-RPMs are automatically signed if `SIGN_PACKAGE` is set to `true`. Signing requires a file `~/.rpmmacros` to be present that contains the signing config (change values as necessary):
+RPMs are automatically signed if `SIGN_PACKAGE` is set to `true`. Signing requires the file  `~/.rpmmacros` to be present with the following signing configuration (change values as necessary):
 
 ```
 %_signature gpg

--- a/linux/README.md
+++ b/linux/README.md
@@ -36,8 +36,7 @@ Deb packages for Debian and Ubuntu (see section *Support Matrix* below for suppo
     -PJDK_MAJOR_VERSION=<majorversion> \
     -PJDK_VERSION=<versionstring> \
     -PJDK_VM=<vm> \
-    -PJDK_ARCHITECTURE=<architecture> \
-    -PDEB_JINFO_PRIORITY=<jinfo>
+    -PJDK_ARCHITECTURE=<architecture>
 ```
 
 `JDK_DISTRIBUTION_DIR` must point to a directory with a binary distribution of AdoptOpenJDK (for example an expanded tarball downloaded from https://adoptopenjdk.net/). Use a JDK distribution to create a JDK package, use a JRE distribution to create a JRE package.
@@ -51,19 +50,18 @@ Example:
     -PJDK_MAJOR_VERSION=11 \
     -PJDK_VERSION="11.0.2+9" \
     -PJDK_VM=hotspot \
-    -PJDK_ARCHITECTURE=amd64 \
-    -PDEB_JINFO_PRIORITY=1101
+    -PJDK_ARCHITECTURE=amd64
 ```
 
 Table with arguments:
 
-|        | JDK\_MAJOR\_VERSION | JDK\_VERSION     | JDK\_VM             | JDK\_ARCHITECTURE                    | DEB\_JINFO\_PRIORITY |
-|--------|---------------------|------------------|---------------------|--------------------------------------|----------------------|
-| JDK 8  | 8                   | e.g. `8u202`     | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1081`               |
-| JDK 9  | 9                   | e.g. `9.0.4+11`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1091`               |
-| JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1101`               |
-| JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1111`               |
-| JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1121`               |
+|        | JDK\_MAJOR\_VERSION | JDK\_VERSION     | JDK\_VM             | JDK\_ARCHITECTURE                    |
+|--------|---------------------|------------------|---------------------|--------------------------------------|
+| JDK 8  | 8                   | e.g. `8u202`     | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 9  | 9                   | e.g. `9.0.4+11`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
 
 ### RPM packages
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -31,6 +31,7 @@ Deb packages for Debian and Ubuntu (see section *Support Matrix* below for suppo
 
 ```
 ./gradlew buildDebPackage \
+    -PJDK_DISTRIBUTION_TYPE=<JDK|JRE> \
     -PJDK_DISTRIBUTION_DIR=/path/to/jdk \
     -PJDK_MAJOR_VERSION=<majorversion> \
     -PJDK_VERSION=<versionstring> \
@@ -39,12 +40,13 @@ Deb packages for Debian and Ubuntu (see section *Support Matrix* below for suppo
     -PDEB_JINFO_PRIORITY=<jinfo>
 ```
 
-`JDK_DISTRIBUTION_DIR` must point to a directory with a binary distribution of AdoptOpenJDK (for example an expanded tarball downloaded from https://adoptopenjdk.net/). 
+`JDK_DISTRIBUTION_DIR` must point to a directory with a binary distribution of AdoptOpenJDK (for example an expanded tarball downloaded from https://adoptopenjdk.net/). Use a JDK distribution to create a JDK package, use a JRE distribution to create a JRE package.
 
 Example:
 
 ```
 ./gradlew buildDebPackage \
+    -PJDK_DISTRIBUTION_TYPE=JDK \
     -PJDK_DISTRIBUTION_DIR=/path/to/jdk-11.0.2+9 \
     -PJDK_MAJOR_VERSION=11 \
     -PJDK_VERSION="11.0.2+9" \
@@ -55,13 +57,13 @@ Example:
 
 Table with arguments:
 
-|        | JDK\_MAJOR\_VERSION | JDK\_VERSION    | JDK\_VM             | JDK\_ARCHITECTURE                    | DEB\_JINFO\_PRIORITY |
-|--------|---------------------|-----------------|---------------------|--------------------------------------|----------------------|
-| JDK 8  | 8                   | e.g. `8u202`    | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1081`               |
-| JDK 9  | 9                   | e.g. `9.0.4+11` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1091`               |
-| JDK 10 | 10                  | e.g. `10.0.2+13`| `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1101`               |
-| JDK 11 | 11                  | e.g. `11.0.2+9` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1111`               |
-| JDK 12 | 12                  |                 | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1121`               |
+|        | JDK\_MAJOR\_VERSION | JDK\_VERSION     | JDK\_VM             | JDK\_ARCHITECTURE                    | DEB\_JINFO\_PRIORITY |
+|--------|---------------------|------------------|---------------------|--------------------------------------|----------------------|
+| JDK 8  | 8                   | e.g. `8u202`     | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1081`               |
+| JDK 9  | 9                   | e.g. `9.0.4+11`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1091`               |
+| JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1101`               |
+| JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1111`               |
+| JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` | `1121`               |
 
 ### RPM packages
 
@@ -69,6 +71,7 @@ RPM packages for CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as Open
 
 ```
 ./gradlew buildRpmPackage \
+    -PJDK_DISTRIBUTION_TYPE=<JDK|JRE> \
     -PJDK_DISTRIBUTION_DIR=/path/to/jdk \
     -PJDK_MAJOR_VERSION=<majorversion> \
     -PJDK_VERSION=<versionstring> \
@@ -77,12 +80,13 @@ RPM packages for CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as Open
     -PSIGN_PACKAGE=<true|false>
 ```
 
-`JDK_DISTRIBUTION_DIR` must point to a directory with a binary distribution of AdoptOpenJDK (for example an expanded tarball downloaded from https://adoptopenjdk.net/). 
+`JDK_DISTRIBUTION_DIR` must point to a directory with a binary distribution of AdoptOpenJDK (for example an expanded tarball downloaded from https://adoptopenjdk.net/). Use a JDK distribution to create a JDK package, use a JRE distribution to create a JRE package. 
 
 Example:
 
 ```
 ./gradlew buildRpmPackage \
+    -PJDK_DISTRIBUTION_TYPE=JRE \
     -PJDK_DISTRIBUTION_DIR=/path/to/jdk-11.0.2+9 \
     -PJDK_MAJOR_VERSION=11 \
     -PJDK_VERSION="11.0.2+9" \
@@ -91,15 +95,15 @@ Example:
     -PSIGN_PACKAGE=true
 ```
 
-|        | JDK\_MAJOR\_VERSION | JDK\_VERSION    | JDK\_VM             | JDK\_ARCHITECTURE                    |
-|--------|---------------------|-----------------|---------------------|--------------------------------------|
-| JDK 8  | 8                   | e.g. `8u202`    | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
-| JDK 9  | 9                   | e.g. `9.0.4+11` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
-| JDK 10 | 10                  | e.g. `10.0.2+13`| `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
-| JDK 11 | 11                  | e.g. `11.0.2+9` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
-| JDK 12 | 12                  |                 | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+|        | JDK\_MAJOR\_VERSION | JDK\_VERSION     | JDK\_VM             | JDK\_ARCHITECTURE                    |
+|--------|---------------------|------------------|---------------------|--------------------------------------|
+| JDK 8  | 8                   | e.g. `8u202`     | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 9  | 9                   | e.g. `9.0.4+11`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
+| JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9` | `amd64`, `s390x`, `ppc64el`, `arm64` |
 
-RPMs are automatically signed if `SIGN_PACKAGE` is set to `true`. Signing require a file `~/.rpmmacros` to be present that contains the signing config (change values as necessary):
+RPMs are automatically signed if `SIGN_PACKAGE` is set to `true`. Signing requires a file `~/.rpmmacros` to be present that contains the signing config (change values as necessary):
 
 ```
 %_signature gpg
@@ -131,7 +135,7 @@ By specifying all build properties (see above) building and uploading can be don
 
 ### Deb packages
 
-All packages can be installed on Debian and Ubuntu without further changes. They are available for amd64, s390x, ppc64el, arm64 unless otherwise noted. All major versions can be installed side by side. 
+All packages can be installed on Debian and Ubuntu without further changes. They are available for amd64, s390x, ppc64el, arm64 unless otherwise noted. All major versions as well as JDKs and JREs can be installed side by side. JDKs and JREs have no dependencies on each other and are completely self-contained.
 
 | OpenJDK                  | Debian                               | Ubuntu                                                        |
 |--------------------------|--------------------------------------|---------------------------------------------------------------|
@@ -146,7 +150,7 @@ All packages can be installed on Debian and Ubuntu without further changes. They
 
 ### RPM packages
 
-All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as OpenSUSE and SUSE Enterprise Linux (SLES) without further changes. All major versions can be installed side by side. Packages for Fedora and OpenSUSE are only available for amd64, packages for all other distributions are available for amd64, s390x, ppc64el and arm64.
+All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as OpenSUSE and SUSE Enterprise Linux (SLES) without further changes. All major versions as well as JDKs and JREs can be installed side by side. JDKs and JREs have no dependencies on each other and are completely self-contained. Packages for Fedora and OpenSUSE are only available for amd64, packages for all other distributions are available for amd64, s390x, ppc64el and arm64.
 
 | OpenJDK                  | CentOS  | Fedora | RHEL    | OpenSUSE | SLES   |
 |--------------------------|---------|--------|---------|----------|--------|

--- a/linux/build.gradle
+++ b/linux/build.gradle
@@ -31,7 +31,7 @@ ext {
     pkgMetadata = [
         architecture: getJdkArchitecture(),
         vm          : getJdkVirtualMachine(),
-        description : "OpenJDK Development Kit ${jdkMajorVersion} (JDK) by AdoptOpenJDK",
+        description : "${jdkDistributionType.description} ${jdkMajorVersion} (${jdkDistributionType.name()}) by AdoptOpenJDK",
         homepage    : "https://adoptopenjdk.net/",
         vcsUrl      : "https://github.com/AdoptOpenJDK/openjdk-jdk${jdkMajorVersion}u",
         iteration   : version,
@@ -49,11 +49,18 @@ ext {
         ],
     ]
     jdkDistributionDir = JDK_DISTRIBUTION_DIR
+    jdkDistributionType = getJdkDistributionType()
 }
 
 tasks.register("upload") {
     group = "upload"
     description = "Uploads all linux packages"
+}
+
+def getJdkDistributionType() {
+    return hasProperty("JDK_DISTRIBUTION_TYPE") ?
+        DistributionType.valueOf(JDK_DISTRIBUTION_TYPE.toUpperCase(Locale.US)) :
+        DistributionType.JDK
 }
 
 def getJdkVirtualMachine() {
@@ -83,4 +90,34 @@ def getJdkMajorVersion() {
         throw new IllegalArgumentException("JDK major version '$version' out of range")
     }
     return version
+}
+
+enum DistributionType {
+    JDK("", "OpenJDK Development Kit"),
+    JRE("jre", "OpenJDK Runtime Environment")
+
+    private final String suffix
+
+    private final String description
+
+    DistributionType(suffix, description) {
+        this.suffix = suffix
+        this.description = description
+    }
+
+    String getSuffix() {
+        return suffix
+    }
+
+    String getPkgNameSuffix() {
+        if (suffix.empty) {
+            return ""
+        }
+
+        return "-${this.suffix}"
+    }
+
+    String getDescription() {
+        return description
+    }
 }

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -1,12 +1,20 @@
 import net.adoptopenjdk.installer.BuildDebianPackage
 import net.adoptopenjdk.installer.UploadDebianPackage
 
+ext.jinfoPriorities = [
+    8 : 1081,
+    9 : 1091,
+    10: 1101,
+    11: 1111,
+    12: 1121
+]
+
 tasks.register("buildDebianPackage", BuildDebianPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
     iteration = version
-    priority = getJinfoPriority()
-    architecture = pkgMetadata.architecture
+    priority = jinfoPriorities[jdkMajorVersion]
+    architecture = pkgMetadata.architecture.debQualifier()
     vm = pkgMetadata.vm
     maintainer = pkgMetadata.maintainer
     vendor = pkgMetadata.vendor
@@ -55,7 +63,3 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
 }
 
 rootProject.tasks.getByName("upload").dependsOn(uploadDebianPackage)
-
-def getJinfoPriority() {
-    return hasProperty("DEB_JINFO_PRIORITY") ? Integer.parseInt(DEB_JINFO_PRIORITY) : 0
-}

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -2,7 +2,7 @@ import net.adoptopenjdk.installer.BuildDebianPackage
 import net.adoptopenjdk.installer.UploadDebianPackage
 
 tasks.register("buildDebianPackage", BuildDebianPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}"
+    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
     iteration = version
     priority = getJinfoPriority()
@@ -14,9 +14,9 @@ tasks.register("buildDebianPackage", BuildDebianPackage) {
     license = pkgMetadata.license
     packageDescription = pkgMetadata.description
     category = "java"
-    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/dependencies.txt")
-    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/provides.txt")
-    toolsFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/tools.txt")
+    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/dependencies.txt")
+    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/provides.txt")
+    toolsFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/tools.txt")
     prefix = "/usr/lib/jvm"
     afterInstallScript = file("config/postinst.sh")
     beforeRemoveScript = file("config/prerm.sh")

--- a/linux/deb/config/jdk-10-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-10-hotspot-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-10-hotspot-jre/provides.txt
+++ b/linux/deb/config/jdk-10-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java-runtime-headless
+java10-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-10-hotspot-jre/tools.txt
+++ b/linux/deb/config/jdk-10-hotspot-jre/tools.txt
@@ -1,0 +1,12 @@
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-10-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-10-openj9-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-10-openj9-jre/provides.txt
+++ b/linux/deb/config/jdk-10-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java-runtime-headless
+java10-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-10-openj9-jre/tools.txt
+++ b/linux/deb/config/jdk-10-openj9-jre/tools.txt
@@ -1,0 +1,12 @@
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-11-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-11-hotspot-jre/provides.txt
+++ b/linux/deb/config/jdk-11-hotspot-jre/provides.txt
@@ -1,0 +1,9 @@
+java-runtime-headless
+java10-runtime-headless
+java11-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-11-hotspot-jre/tools.txt
+++ b/linux/deb/config/jdk-11-hotspot-jre/tools.txt
@@ -1,0 +1,10 @@
+bin/jaotc hl
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-11-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-11-openj9-jre/provides.txt
+++ b/linux/deb/config/jdk-11-openj9-jre/provides.txt
@@ -1,0 +1,9 @@
+java-runtime-headless
+java10-runtime-headless
+java11-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-11-openj9-jre/tools.txt
+++ b/linux/deb/config/jdk-11-openj9-jre/tools.txt
@@ -1,0 +1,10 @@
+bin/jaotc hl
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-12-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-12-hotspot-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-12-hotspot-jre/provides.txt
+++ b/linux/deb/config/jdk-12-hotspot-jre/provides.txt
@@ -1,0 +1,10 @@
+java-runtime-headless
+java10-runtime-headless
+java11-runtime-headless
+java12-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-12-hotspot-jre/tools.txt
+++ b/linux/deb/config/jdk-12-hotspot-jre/tools.txt
@@ -1,0 +1,12 @@
+bin/jaotc hl
+bin/java hl
+bin/jfr hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/unpack200 hl
+lib/jexec hl
+lib/jspawnhelper hl

--- a/linux/deb/config/jdk-12-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-12-openj9-jre/dependencies.txt
@@ -1,0 +1,9 @@
+ca-certificates
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-12-openj9-jre/provides.txt
+++ b/linux/deb/config/jdk-12-openj9-jre/provides.txt
@@ -1,0 +1,10 @@
+java-runtime-headless
+java10-runtime-headless
+java11-runtime-headless
+java12-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-12-openj9-jre/tools.txt
+++ b/linux/deb/config/jdk-12-openj9-jre/tools.txt
@@ -1,0 +1,11 @@
+bin/java hl
+bin/jfr hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/pack200 hl
+bin/rmid hl
+bin/rmiregistry hl
+bin/unpack200 hl
+lib/jexec hl
+lib/jspawnhelper hl

--- a/linux/deb/config/jdk-8-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-8-hotspot-jre/provides.txt
+++ b/linux/deb/config/jdk-8-hotspot-jre/provides.txt
@@ -1,0 +1,6 @@
+java-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless

--- a/linux/deb/config/jdk-8-hotspot-jre/tools.txt
+++ b/linux/deb/config/jdk-8-hotspot-jre/tools.txt
@@ -1,0 +1,12 @@
+bin/java hl
+bin/jjs hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/policytool jre
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
@@ -1,0 +1,11 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libssl1.1
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates
 java-common
 libasound2
 libc6
-libssl1.1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-openj9-jre/provides.txt
+++ b/linux/deb/config/jdk-8-openj9-jre/provides.txt
@@ -1,0 +1,6 @@
+java-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless

--- a/linux/deb/config/jdk-8-openj9-jre/tools.txt
+++ b/linux/deb/config/jdk-8-openj9-jre/tools.txt
@@ -1,0 +1,13 @@
+bin/java hl
+bin/jextract hl
+bin/jjs hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/policytool jre
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-8-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9/dependencies.txt
@@ -2,7 +2,6 @@ ca-certificates
 java-common
 libasound2
 libc6
-libssl1.1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-9-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-9-hotspot-jre/dependencies.txt
@@ -1,0 +1,11 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g
+libelf1

--- a/linux/deb/config/jdk-9-hotspot-jre/provides.txt
+++ b/linux/deb/config/jdk-9-hotspot-jre/provides.txt
@@ -1,0 +1,7 @@
+java-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-9-hotspot-jre/tools.txt
+++ b/linux/deb/config/jdk-9-hotspot-jre/tools.txt
@@ -1,0 +1,13 @@
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/policytool jre
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/deb/config/jdk-9-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-9-openj9-jre/dependencies.txt
@@ -1,0 +1,10 @@
+ca-certificates
+java-common
+libasound2
+libc6
+libx11-6
+libxext6
+libxi6
+libxrender1
+libxtst6
+zlib1g

--- a/linux/deb/config/jdk-9-openj9-jre/provides.txt
+++ b/linux/deb/config/jdk-9-openj9-jre/provides.txt
@@ -1,0 +1,7 @@
+java-runtime-headless
+java2-runtime-headless
+java5-runtime-headless
+java6-runtime-headless
+java7-runtime-headless
+java8-runtime-headless
+java9-runtime-headless

--- a/linux/deb/config/jdk-9-openj9-jre/tools.txt
+++ b/linux/deb/config/jdk-9-openj9-jre/tools.txt
@@ -1,0 +1,13 @@
+bin/java hl
+bin/jjs hl
+bin/jrunscript hl
+bin/keytool hl
+bin/orbd hl
+bin/pack200 hl
+bin/policytool jre
+bin/rmid hl
+bin/rmiregistry hl
+bin/servertool hl
+bin/tnameserv hl
+bin/unpack200 hl
+lib/jexec hl

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -2,7 +2,7 @@ import net.adoptopenjdk.installer.BuildRpmPackage
 import net.adoptopenjdk.installer.UploadRpmPackage
 
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}"
+    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture
@@ -13,10 +13,10 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
     license = pkgMetadata.license
     packageDescription = pkgMetadata.description
     category = "java"
-    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/dependencies.txt")
-    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/provides.txt")
+    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/dependencies.txt")
+    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/provides.txt")
     prefix = "/usr/lib/jvm"
-    afterInstallScript = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/postinst.sh")
+    afterInstallScript = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/postinst.sh")
     beforeRemoveScript = file("config/prerm.sh")
     prebuiltJdkDirectory = jdkDistributionDir
     variant = "redhat"
@@ -24,7 +24,7 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
 }
 
 tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}"
+    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture
@@ -35,10 +35,10 @@ tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
     license = pkgMetadata.license
     packageDescription = pkgMetadata.description
     category = "java"
-    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/dependencies.txt")
-    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/provides.txt")
+    dependenciesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/dependencies.txt")
+    providesFile = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/provides.txt")
     prefix = pkgMetadata.architecture.isaBits() == 64 ? "/usr/lib64/jvm" : "/usr/lib/jvm"
-    afterInstallScript = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}/postinst.sh")
+    afterInstallScript = file("config/jdk-${jdkMajorVersion}-${pkgMetadata.vm}${jdkDistributionType.pkgNameSuffix}/postinst.sh")
     beforeRemoveScript = file("config/prerm.sh")
     prebuiltJdkDirectory = jdkDistributionDir
     variant = "suse"

--- a/linux/rpm/config/jdk-10-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-10-hotspot-jre/dependencies.txt
@@ -1,0 +1,15 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-10-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-10-hotspot-jre/postinst.sh
@@ -1,0 +1,25 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1101 \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-10-hotspot-jre/provides.txt
+++ b/linux/rpm/config/jdk-10-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-10
+java-10-openjdk
+java-openjdk
+jre
+jre-10
+jre-10-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-10-hotspot/provides.txt
+++ b/linux/rpm/config/jdk-10-hotspot/provides.txt
@@ -1,7 +1,13 @@
 java
 java-10
+java-10-devel
 java-10-openjdk
+java-10-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-10
+java-sdk-10-openjdk
 jre
 jre-10
 jre-10-openjdk

--- a/linux/rpm/config/jdk-10-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-10-openj9-jre/dependencies.txt
@@ -1,0 +1,17 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libgcc_s.so.1()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+librt.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-10-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-10-openj9-jre/postinst.sh
@@ -1,0 +1,25 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1101 \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-10-openj9-jre/provides.txt
+++ b/linux/rpm/config/jdk-10-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-10
+java-10-openjdk
+java-openjdk
+jre
+jre-10
+jre-10-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-10-openj9/provides.txt
+++ b/linux/rpm/config/jdk-10-openj9/provides.txt
@@ -1,7 +1,13 @@
 java
 java-10
+java-10-devel
 java-10-openjdk
+java-10-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-10
+java-sdk-10-openjdk
 jre
 jre-10
 jre-10-openjdk

--- a/linux/rpm/config/jdk-11-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-11-hotspot-jre/dependencies.txt
@@ -1,0 +1,15 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-11-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-11-hotspot-jre/postinst.sh
@@ -1,0 +1,20 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1111 \
+                        --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-11-hotspot-jre/provides.txt
+++ b/linux/rpm/config/jdk-11-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-11
+java-11-openjdk
+java-openjdk
+jre
+jre-11
+jre-11-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-11-hotspot/provides.txt
+++ b/linux/rpm/config/jdk-11-hotspot/provides.txt
@@ -1,7 +1,13 @@
 java
 java-11
+java-11-devel
 java-11-openjdk
+java-11-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-11
+java-sdk-11-openjdk
 jre
 jre-11
 jre-11-openjdk

--- a/linux/rpm/config/jdk-11-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-11-openj9-jre/dependencies.txt
@@ -1,0 +1,15 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+librt.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-11-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-11-openj9-jre/postinst.sh
@@ -1,0 +1,20 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1111 \
+                        --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-11-openj9-jre/provides.txt
+++ b/linux/rpm/config/jdk-11-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-11
+java-11-openjdk
+java-openjdk
+jre
+jre-11
+jre-11-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-11-openj9/provides.txt
+++ b/linux/rpm/config/jdk-11-openj9/provides.txt
@@ -1,7 +1,13 @@
 java
 java-11
+java-11-devel
 java-11-openjdk
+java-11-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-11
+java-sdk-11-openjdk
 jre
 jre-11
 jre-11-openjdk

--- a/linux/rpm/config/jdk-12-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-12-hotspot-jre/dependencies.txt
@@ -1,0 +1,15 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-12-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-12-hotspot-jre/postinst.sh
@@ -1,0 +1,22 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+                        --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
+                        --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/bin/jspawnhelper jspawnhelper {{ prefix }}/{{ jdkDirectoryName }}/lib/jspawnhelper \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-12-hotspot-jre/provides.txt
+++ b/linux/rpm/config/jdk-12-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-12
+java-12-openjdk
+java-openjdk
+jre
+jre-12
+jre-12-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-12-hotspot/provides.txt
+++ b/linux/rpm/config/jdk-12-hotspot/provides.txt
@@ -1,7 +1,13 @@
 java
 java-12
+java-12-devel
 java-12-openjdk
+java-12-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-12
+java-sdk-12-openjdk
 jre
 jre-12
 jre-12-openjdk

--- a/linux/rpm/config/jdk-12-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-12-openj9-jre/dependencies.txt
@@ -1,0 +1,15 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+librt.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-12-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-12-openj9-jre/postinst.sh
@@ -1,0 +1,21 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+                        --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/bin/jspawnhelper jspawnhelper {{ prefix }}/{{ jdkDirectoryName }}/lib/jspawnhelper \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-12-openj9-jre/provides.txt
+++ b/linux/rpm/config/jdk-12-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-12
+java-12-openjdk
+java-openjdk
+jre
+jre-12
+jre-12-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-12-openj9/provides.txt
+++ b/linux/rpm/config/jdk-12-openj9/provides.txt
@@ -1,7 +1,13 @@
 java
 java-12
+java-12-devel
 java-12-openjdk
+java-12-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-12
+java-sdk-12-openjdk
 jre
 jre-12
 jre-12-openjdk

--- a/linux/rpm/config/jdk-8-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-8-hotspot-jre/dependencies.txt
@@ -1,0 +1,16 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libgcc_s.so.1()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-8-hotspot-jre/postinst.sh
@@ -1,0 +1,25 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1081 \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/policytool policytool {{ prefix }}/{{ jdkDirectoryName }}/bin/policytool \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/policytool.1 policytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/policytool.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-8-hotspot-jre/provides.txt
+++ b/linux/rpm/config/jdk-8-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-1.8.0
+java-1.8.0-openjdk
+java-openjdk
+jre
+jre-1.8.0
+jre-1.8.0-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-8-hotspot/provides.txt
+++ b/linux/rpm/config/jdk-8-hotspot/provides.txt
@@ -1,7 +1,13 @@
 java
 java-1.8.0
+java-1.8.0-devel
 java-1.8.0-openjdk
+java-1.8.0-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-1.8.0
+java-sdk-1.8.0-openjdk
 jre
 jre-1.8.0
 jre-1.8.0-openjdk

--- a/linux/rpm/config/jdk-8-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-8-openj9-jre/dependencies.txt
@@ -1,0 +1,16 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libgcc_s.so.1()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+librt.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-8-openj9-jre/postinst.sh
@@ -1,0 +1,26 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1081 \
+                        --slave /usr/bin/jextract jextract {{ prefix }}/{{ jdkDirectoryName }}/bin/jextract \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/policytool policytool {{ prefix }}/{{ jdkDirectoryName }}/bin/policytool \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/policytool.1 policytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/policytool.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-8-openj9-jre/provides.txt
+++ b/linux/rpm/config/jdk-8-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-1.8.0
+java-1.8.0-openjdk
+java-openjdk
+jre
+jre-1.8.0
+jre-1.8.0-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-8-openj9/provides.txt
+++ b/linux/rpm/config/jdk-8-openj9/provides.txt
@@ -1,7 +1,13 @@
 java
 java-1.8.0
+java-1.8.0-devel
 java-1.8.0-openjdk
+java-1.8.0-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-1.8.0
+java-sdk-1.8.0-openjdk
 jre
 jre-1.8.0
 jre-1.8.0-openjdk

--- a/linux/rpm/config/jdk-9-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-9-hotspot-jre/dependencies.txt
@@ -1,0 +1,17 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libelf.so.1()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libgcc_s.so.1()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-9-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-9-hotspot-jre/postinst.sh
@@ -1,0 +1,27 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1091 \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/policytool policytool {{ prefix }}/{{ jdkDirectoryName }}/bin/policytool \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/policytool.1 policytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/policytool.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-9-hotspot-jre/provides.txt
+++ b/linux/rpm/config/jdk-9-hotspot-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-9
+java-9-openjdk
+java-openjdk
+jre
+jre-9
+jre-9-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-9-hotspot/provides.txt
+++ b/linux/rpm/config/jdk-9-hotspot/provides.txt
@@ -1,7 +1,13 @@
 java
 java-9
+java-9-devel
 java-9-openjdk
+java-9-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-9
+java-sdk-9-openjdk
 jre
 jre-9
 jre-9-openjdk

--- a/linux/rpm/config/jdk-9-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-9-openj9-jre/dependencies.txt
@@ -1,0 +1,17 @@
+/bin/sh
+/usr/sbin/alternatives
+ca-certificates
+libX11.so.6()({{rpmIsaBits}})
+libXext.so.6()({{rpmIsaBits}})
+libXi.so.6()({{rpmIsaBits}})
+libXrender.so.1()({{rpmIsaBits}})
+libXtst.so.6()({{rpmIsaBits}})
+libasound.so.2()({{rpmIsaBits}})
+libc.so.6()({{rpmIsaBits}})
+libelf.so.1()({{rpmIsaBits}})
+libdl.so.2()({{rpmIsaBits}})
+libgcc_s.so.1()({{rpmIsaBits}})
+libm.so.6()({{rpmIsaBits}})
+libpthread.so.0()({{rpmIsaBits}})
+libthread_db.so.1()({{rpmIsaBits}})
+libz.so.1()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-9-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-9-openj9-jre/postinst.sh
@@ -1,0 +1,27 @@
+if [ $1 -ge 1 ] ; then
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1091 \
+                        --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
+                        --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
+                        --slave /usr/bin/keytool keytool {{ prefix }}/{{ jdkDirectoryName }}/bin/keytool \
+                        --slave /usr/bin/orbd orbd {{ prefix }}/{{ jdkDirectoryName }}/bin/orbd \
+                        --slave /usr/bin/pack200 pack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/pack200 \
+                        --slave /usr/bin/policytool policytool {{ prefix }}/{{ jdkDirectoryName }}/bin/policytool \
+                        --slave /usr/bin/rmid rmid {{ prefix }}/{{ jdkDirectoryName }}/bin/rmid \
+                        --slave /usr/bin/rmiregistry rmiregistry {{ prefix }}/{{ jdkDirectoryName }}/bin/rmiregistry \
+                        --slave /usr/bin/servertool servertool {{ prefix }}/{{ jdkDirectoryName }}/bin/servertool \
+                        --slave /usr/bin/tnameserv tnameserv {{ prefix }}/{{ jdkDirectoryName }}/bin/tnameserv \
+                        --slave /usr/bin/unpack200 unpack200 {{ prefix }}/{{ jdkDirectoryName }}/bin/unpack200 \
+                        --slave /usr/bin/jexec jexec {{ prefix }}/{{ jdkDirectoryName }}/lib/jexec \
+                        --slave /usr/share/man/man1/java.1 java.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/java.1 \
+                        --slave /usr/share/man/man1/jjs.1 jjs.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jjs.1 \
+                        --slave /usr/share/man/man1/jrunscript.1 jrunscript.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/jrunscript.1 \
+                        --slave /usr/share/man/man1/keytool.1 keytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/keytool.1 \
+                        --slave /usr/share/man/man1/orbd.1 orbd.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/orbd.1 \
+                        --slave /usr/share/man/man1/pack200.1 pack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/pack200.1 \
+                        --slave /usr/share/man/man1/policytool.1 policytool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/policytool.1 \
+                        --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
+                        --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
+                        --slave /usr/share/man/man1/servertool.1 servertool.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/servertool.1 \
+                        --slave /usr/share/man/man1/tnameserv.1 tnameserv.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/tnameserv.1 \
+                        --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
+fi

--- a/linux/rpm/config/jdk-9-openj9-jre/provides.txt
+++ b/linux/rpm/config/jdk-9-openj9-jre/provides.txt
@@ -1,0 +1,8 @@
+java
+java-9
+java-9-openjdk
+java-openjdk
+jre
+jre-9
+jre-9-openjdk
+jre-openjdk

--- a/linux/rpm/config/jdk-9-openj9/provides.txt
+++ b/linux/rpm/config/jdk-9-openj9/provides.txt
@@ -1,7 +1,13 @@
 java
 java-9
+java-9-devel
 java-9-openjdk
+java-9-openjdk-devel
+java-devel
 java-openjdk
+java-openjdk-devel
+java-sdk-9
+java-sdk-9-openjdk
 jre
 jre-9
 jre-9-openjdk


### PR DESCRIPTION
With this pull requests it's possible to build Linux packages from an AdoptOpenJDK JRE distribution. 

The JREs are completely separate from the JDKs and there's no dependency between those because at least from JDK 9 onwards JDK and JRE overlap and fixing those overlaps isn't worth it. If you need `java` and `javac`, install the JDK. If you only need `java`, install the JRE. If you notice later on that `javac` would come handy, install the JDK and optionally remove the JRE.

Example output from CentOS 7:

```
[root@c54190d7572b /]# yum search adoptopenjdk
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: pkg.adfinis-sygroup.ch
 * extras: pkg.adfinis-sygroup.ch
 * updates: pkg.adfinis-sygroup.ch
============================================== N/S matched: adoptopenjdk ===============================================
adoptopenjdk-12-hotspot-jre.x86_64 : OpenJDK Runtime Environment 12 (JRE) by AdoptOpenJDK

  Name and summary matches only, use "search all" for everything.
[root@c54190d7572b /]# yum info adoptopenjdk-12-hotspot-jre.x86_64
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: pkg.adfinis-sygroup.ch
 * extras: pkg.adfinis-sygroup.ch
 * updates: pkg.adfinis-sygroup.ch
Installed Packages
Name        : adoptopenjdk-12-hotspot-jre
Arch        : x86_64
Version     : 12.0.1+12
Release     : 1
Size        : 138 M
Repo        : installed
Summary     : OpenJDK Runtime Environment 12 (JRE) by AdoptOpenJDK
URL         : https://adoptopenjdk.net/
License     : GPL-2.0+CE
Description : OpenJDK Runtime Environment 12 (JRE) by AdoptOpenJDK

[root@c54190d7572b /]# ls -l /usr/lib/jvm
total 4
drwxr-xr-x 6 root root 4096 May  1 06:58 adoptopenjdk-12-hotspot-jre
[root@c54190d7572b /]# java -version
openjdk version "12.0.1" 2019-04-16
OpenJDK Runtime Environment AdoptOpenJDK (build 12.0.1+12)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 12.0.1+12, mixed mode, sharing)
```

Changes required to the build pipeline:

* `-PJDK_DISTRIBUTION_TYPE=<JDK|JRE>` needs to be added.
* `-PDEB_JINFO_PRIORITY` can be dropped.