### PR TITLE
Update supported Linux distributions

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -151,8 +151,8 @@ All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL)
 
 | OpenJDK                  | CentOS | Fedora | RHEL | OpenSUSE | SLES   |
 |--------------------------|--------|--------|------|----------|--------|
-| JDK 8 (Hotspot, OpenJ9)  | 6, 7   | 28, 29 | 6, 7 | 15.0     | 12, 15 |
-| JDK 9 (Hotspot, OpenJ9)  | 6, 7   | 28, 29 | 6, 7 | 15.0     | 12, 15 |
-| JDK 10 (Hotspot, OpenJ9) | 6, 7   | 28, 29 | 6, 7 | 15.0     | 12, 15 |
-| JDK 11 (Hotspot, OpenJ9) | 6, 7   | 28, 29 | 6, 7 | 15.0     | 12, 15 |
-| JDK 12 (Hotspot, OpenJ9) | 6, 7   | 28, 29 | 6, 7 | 15.0     | 12, 15 |
+| JDK 8 (Hotspot, OpenJ9)  | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+| JDK 9 (Hotspot, OpenJ9)  | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+| JDK 10 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+| JDK 11 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+| JDK 12 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |

--- a/linux/README.md
+++ b/linux/README.md
@@ -135,15 +135,13 @@ By specifying all build properties (see above) building and uploading can be don
 
 All packages can be installed on Debian and Ubuntu without further changes. They are available for amd64, s390x, ppc64el, arm64 unless otherwise noted. All major versions can be installed side by side. 
 
-| OpenJDK                  | Debian                               | Ubuntu                                                          |
-|--------------------------|--------------------------------------|-----------------------------------------------------------------|
-| JDK 8 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 14.04* (trusty), 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic) |
-| JDK 9 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 14.04* (trusty), 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic) |
-| JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 14.04* (trusty), 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic) |
-| JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 14.04* (trusty), 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic) |
-| JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 14.04* (trusty), 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic) |
-
-\* amd64, ppc64el, arm64 only
+| OpenJDK                  | Debian                               | Ubuntu                                                        |
+|--------------------------|--------------------------------------|---------------------------------------------------------------|
+| JDK 8 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic), 19.04 (disco) |
+| JDK 9 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic), 19.04 (disco) |
+| JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic), 19.04 (disco) |
+| JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic), 19.04 (disco) |
+| JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 18.10 (cosmic), 19.04 (disco) |
 
 * [Debian releases and support timeframe](https://wiki.debian.org/DebianReleases)
 * [Ubuntu releases and support timeframe](https://wiki.ubuntu.com/Releases)

--- a/linux/README.md
+++ b/linux/README.md
@@ -150,13 +150,13 @@ All packages can be installed on Debian and Ubuntu without further changes. They
 
 All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as OpenSUSE and SUSE Enterprise Linux (SLES) without further changes. All major versions can be installed side by side. Packages for Fedora and OpenSUSE are only available for amd64, packages for all other distributions are available for amd64, s390x, ppc64el and arm64.
 
-| OpenJDK                  | CentOS | Fedora | RHEL | OpenSUSE | SLES   |
-|--------------------------|--------|--------|------|----------|--------|
-| JDK 8 (Hotspot, OpenJ9)  | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
-| JDK 9 (Hotspot, OpenJ9)  | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
-| JDK 10 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
-| JDK 11 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
-| JDK 12 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+| OpenJDK                  | CentOS  | Fedora | RHEL    | OpenSUSE | SLES   |
+|--------------------------|---------|--------|---------|----------|--------|
+| JDK 8 (Hotspot, OpenJ9)  | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0     | 12, 15 |
+| JDK 9 (Hotspot, OpenJ9)  | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0     | 12, 15 |
+| JDK 10 (Hotspot, OpenJ9) | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0     | 12, 15 |
+| JDK 11 (Hotspot, OpenJ9) | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0     | 12, 15 |
+| JDK 12 (Hotspot, OpenJ9) | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0     | 12, 15 |
 
 * [CentOS releases and support timeframe](https://wiki.centos.org/Download)
 * [Fedora releases and support timeframe](https://fedoraproject.org/wiki/Releases)

--- a/linux/README.md
+++ b/linux/README.md
@@ -145,6 +145,9 @@ All packages can be installed on Debian and Ubuntu without further changes. They
 
 \* amd64, ppc64el, arm64 only
 
+* [Debian releases and support timeframe](https://wiki.debian.org/DebianReleases)
+* [Ubuntu releases and support timeframe](https://wiki.ubuntu.com/Releases)
+
 ### RPM packages
 
 All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as OpenSUSE and SUSE Enterprise Linux (SLES) without further changes. All major versions can be installed side by side. Packages for Fedora and OpenSUSE are only available for amd64, packages for all other distributions are available for amd64, s390x, ppc64el and arm64.
@@ -156,3 +159,9 @@ All packages can be installed on CentOS, Fedora, Red Hat Enterprise Linux (RHEL)
 | JDK 10 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
 | JDK 11 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
 | JDK 12 (Hotspot, OpenJ9) | 6, 7   | 29, 30 | 6, 7 | 15.0     | 12, 15 |
+
+* [CentOS releases and support timeframe](https://wiki.centos.org/Download)
+* [Fedora releases and support timeframe](https://fedoraproject.org/wiki/Releases)
+* [Red Hat Enterprise Linux releases and support timeframe](https://access.redhat.com/support/policy/updates/errata/)
+* [OpenSUSE releases and support timeframe](https://en.opensuse.org/Lifetime)
+* [Suse Linux Enterprise releases and support timeframe](https://www.suse.com/lifecycle/)

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -43,7 +43,7 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
     architecture = buildDebianPackage.getArchitecture()
     releaseArchitecture amd64: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["trusty", "xenial", "bionic", "cosmic", "disco"]
+        ubuntu: ["xenial", "bionic", "cosmic", "disco"]
     ]
     releaseArchitecture s390x: [
         debian: ["jessie", "stretch", "buster"],
@@ -51,11 +51,11 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
     ]
     releaseArchitecture ppc64el: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["trusty", "xenial", "bionic", "cosmic", "disco"]
+        ubuntu: ["xenial", "bionic", "cosmic", "disco"]
     ]
     releaseArchitecture arm64: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["trusty", "xenial", "bionic", "cosmic", "disco"]
+        ubuntu: ["xenial", "bionic", "cosmic", "disco"]
     ]
     autoPublish = BINTRAY_AUTO_PUBLISH
     autoCreatePackage = true

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -68,7 +68,7 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
     releaseArchitecture x86_64: [
         centos: ["6", "7"],
         rhel  : ["6", "7"],
-        fedora: ["28", "29"]
+        fedora: ["29", "30"]
     ]
     releaseArchitecture s390x: [
         centos: ["6", "7"],

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -66,21 +66,21 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
     vcsUrl = pkgMetadata.vcsUrl
     architecture = buildRedHatRpmPackage.getArchitecture()
     releaseArchitecture x86_64: [
-        centos: ["6", "7"],
-        rhel  : ["6", "7"],
+        centos: ["6", "7", "8"],
+        rhel  : ["6", "7", "8"],
         fedora: ["29", "30"]
     ]
     releaseArchitecture s390x: [
-        centos: ["6", "7"],
-        rhel  : ["6", "7"]
+        centos: ["6", "7", "8"],
+        rhel  : ["6", "7", "8"]
     ]
     releaseArchitecture ppc64le: [
-        centos: ["6", "7"],
-        rhel  : ["6", "7"]
+        centos: ["6", "7", "8"],
+        rhel  : ["6", "7", "8"]
     ]
     releaseArchitecture aarch64: [
-        centos: ["6", "7"],
-        rhel  : ["6", "7"]
+        centos: ["6", "7", "8"],
+        rhel  : ["6", "7", "8"]
     ]
     autoPublish = BINTRAY_AUTO_PUBLISH
     autoCreatePackage = true


### PR DESCRIPTION
* Fedora: Drop 28, add 30
* CentOS, RHEL: Add 8
* Ubuntu: Drop Trusty