### PR TITLE
Remove ca-certificates-java dependency from Debian packages

### DIFF
--- a/linux/deb/config/jdk-10-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-10-hotspot/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-10-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-10-openj9/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-11-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-11-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-12-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-12-hotspot/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-12-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-12-openj9/dependencies.txt
@@ -1,3 +1,4 @@
+ca-certificates
 libasound2
 libc6
 libx11-6

--- a/linux/deb/config/jdk-8-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-8-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-9-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-9-hotspot/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6

--- a/linux/deb/config/jdk-9-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-9-openj9/dependencies.txt
@@ -1,4 +1,4 @@
-ca-certificates-java
+ca-certificates
 java-common
 libasound2
 libc6


### PR DESCRIPTION
Its circular dependency with the JDK packages makes the AdoptOpenJDK packages uninstallable on Debian (see #105). Trying to somehow get it to install anyway would result in brittle packages because apt/dpkg provides no guarantees how dependency cycles are going to be resolved.

Without ca-certificates-java, the JDK tools will use the default truststore shipped with the JDK.

This is most likely just an interim fix for #105. I plan to bring back the functionality of `ca-certificates-java` without having to install `ca-certificates-java`.