### PR TITLE
Add tasks to remove outdated nightly builds

### DIFF
--- a/linux/build.gradle
+++ b/linux/build.gradle
@@ -57,6 +57,11 @@ tasks.register("upload") {
     description = "Uploads all linux packages"
 }
 
+tasks.register("cleanupNightlyBuilds") {
+    group = "upload"
+    description = "Removes all outdated nightly builds"
+}
+
 def getJdkDistributionType() {
     return hasProperty("JDK_DISTRIBUTION_TYPE") ?
         DistributionType.valueOf(JDK_DISTRIBUTION_TYPE.toUpperCase(Locale.US)) :

--- a/linux/buildSrc/src/functTest/groovy/net/adoptopenjdk/installer/RemoveObsoletePackagesTest.groovy
+++ b/linux/buildSrc/src/functTest/groovy/net/adoptopenjdk/installer/RemoveObsoletePackagesTest.groovy
@@ -1,0 +1,205 @@
+package net.adoptopenjdk.installer
+
+import okhttp3.Credentials
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import static org.assertj.core.api.Assertions.assertThat
+
+class RemoveObsoletePackagesTest {
+    @TempDir
+    public File tempProjectDir
+
+    File settingsFile
+    File buildFile
+
+    MockWebServer mws = new MockWebServer()
+
+    @BeforeEach
+    void setUp() {
+        settingsFile = new File(tempProjectDir, "settings.gradle")
+        buildFile = new File(tempProjectDir, "build.gradle")
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.mws.shutdown()
+    }
+
+    @Test
+    void debPackagesRemovedThatAreOlderThanSevenDays() {
+        String searchResponseBody = """
+            {
+              "results" : [ {
+                "uri" : "https://example.com/api/storage/deb-nightly/dists/bionic/main/binary-i386/Packages",
+                "created" : "2019-05-15T20:01:56.257Z"
+              }, {
+                "uri" : "https://example.com/api/storage/deb-nightly/dists/bionic/main/binary-i386/Packages.bz2",
+                "created" : "2019-05-15T20:01:56.586Z"
+              }, {
+                "uri" : "https://example.com/api/storage/deb-nightly/dists/bionic/main/binary-i386/Packages.gz",
+                "created" : "2019-05-15T20:01:56.557Z"
+              }, {
+                "uri" : "https://example.com/api/storage/deb-nightly/pool/main/a/adoptopenjdk-11-hotspot/adoptopenjdk-11-hotspot_11.0.3+7-201905151809-1_amd64.deb",
+                "created" : "2019-05-16T00:43:15.522Z"
+              }, {
+                "uri" : "https://example.com/api/storage/deb-nightly/pool/main/a/adoptopenjdk-11-hotspot/adoptopenjdk-11-hotspot_11.0.3+7-201905151811-1_ppc64el.deb",
+                "created" : "2019-05-16T02:14:12.282Z"
+              } ]
+            }
+        """
+        MockResponse searchResponse = new MockResponse()
+                .setResponseCode(200)
+                .setBody(searchResponseBody)
+
+        this.mws.enqueue(searchResponse)
+
+        MockResponse deleteResponse = new MockResponse()
+                .setResponseCode(204)
+
+        // Two deb packages should be deleted
+        this.mws.enqueue(deleteResponse)
+        this.mws.enqueue(deleteResponse)
+
+        settingsFile << "rootProject.name = 'deb'"
+        buildFile << """
+            plugins {
+                id "net.adoptopenjdk.installer"
+            }
+
+            import java.time.Instant
+            import java.time.ZoneId
+            tasks.register("removeDebianNightlyBuilds", net.adoptopenjdk.installer.RemoveObsoletePackages) {
+                apiEndpoint = "${this.mws.url("/")}"
+                user = "aUser"
+                password = "aKey"
+                repository = "deb-nightly"
+                daysToKeep = 7
+                clock = Clock.fixed(Instant.ofEpochMilli(1559993456971), ZoneId.of("UTC"))
+            }
+        """
+
+        def result = GradleRunner.create()
+                .withProjectDir(tempProjectDir)
+                .withArguments("removeDebianNightlyBuilds")
+                .withPluginClasspath()
+                .build()
+
+        assertThat(this.mws.requestCount).isEqualTo(3)
+
+        RecordedRequest searchRequest = this.mws.takeRequest()
+
+        assertThat(searchRequest.path)
+                .isEqualTo("/api/search/creation?from=0&to=1559388656971&repos=deb-nightly")
+        assertThat(searchRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        RecordedRequest firstDeleteRequest = this.mws.takeRequest()
+
+        assertThat(firstDeleteRequest.path)
+                .isEqualTo("/deb-nightly/pool/main/a/adoptopenjdk-11-hotspot/adoptopenjdk-11-hotspot_11.0.3+7-201905151809-1_amd64.deb")
+        assertThat(firstDeleteRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        RecordedRequest secondDeleteRequest = this.mws.takeRequest()
+
+        assertThat(secondDeleteRequest.path)
+                .isEqualTo("/deb-nightly/pool/main/a/adoptopenjdk-11-hotspot/adoptopenjdk-11-hotspot_11.0.3+7-201905151811-1_ppc64el.deb")
+        assertThat(secondDeleteRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        assertThat(result.task(":removeDebianNightlyBuilds").outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    void rpmPackagesRemovedThatAreOlderThanOneDay() {
+        String searchResponseBody = """
+            {
+              "results" : [ {
+                "uri" : "https://example.com/api/storage/rpm-nightly/centos/6/x86_64/Packages/adoptopenjdk-12-hotspot-12.0.1+12-1.x86_64.rpm",
+                "created" : "2019-05-19T10:41:51.142Z"
+              }, {
+                "uri" : "https://example.com/api/storage/rpm-nightly/centos/6/x86_64/repodata/repomd.xml",
+                "created" : "2019-05-19T10:41:51.660Z"
+              }, {
+                "uri" : "https://example.com/api/storage/rpm-nightly/centos/6/x86_64/repodata/repomd.xml.asc",
+                "created" : "2019-05-19T10:41:51.929Z"
+              }, {
+                "uri" : "https://example.com/api/storage/rpm-nightly/centos/6/x86_64/repodata/repomd.xml.key",
+                "created" : "2019-05-19T10:41:51.950Z"
+              }, {
+                "uri" : "https://example.com/api/storage/rpm-nightly/centos/7/x86_64/Packages/adoptopenjdk-12-hotspot-12.0.1+12-1.x86_64.rpm",
+                "created" : "2019-05-19T10:41:52.314Z"
+              } ]
+            }
+        """
+        MockResponse searchResponse = new MockResponse()
+                .setResponseCode(200)
+                .setBody(searchResponseBody)
+
+        this.mws.enqueue(searchResponse)
+
+        MockResponse deleteResponse = new MockResponse()
+                .setResponseCode(204)
+
+        // Two rpm packages should be deleted
+        this.mws.enqueue(deleteResponse)
+        this.mws.enqueue(deleteResponse)
+
+        settingsFile << "rootProject.name = 'rpm'"
+        buildFile << """
+            plugins {
+                id "net.adoptopenjdk.installer"
+            }
+
+            import java.time.Instant
+            import java.time.ZoneId
+            tasks.register("removeRpmNightlyBuilds", net.adoptopenjdk.installer.RemoveObsoletePackages) {
+                apiEndpoint = "${this.mws.url("/")}"
+                user = "aUser"
+                password = "aKey"
+                repository = "rpm-nightly"
+                daysToKeep = 1
+                clock = Clock.fixed(Instant.ofEpochMilli(1559994459882), ZoneId.of("UTC"))
+            }
+        """
+
+        def result = GradleRunner.create()
+                .withProjectDir(tempProjectDir)
+                .withArguments("removeRpmNightlyBuilds")
+                .withPluginClasspath()
+                .build()
+
+        assertThat(this.mws.requestCount).isEqualTo(3)
+
+        RecordedRequest searchRequest = this.mws.takeRequest()
+
+        assertThat(searchRequest.path)
+                .isEqualTo("/api/search/creation?from=0&to=1559908059882&repos=rpm-nightly")
+        assertThat(searchRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        RecordedRequest firstDeleteRequest = this.mws.takeRequest()
+
+        assertThat(firstDeleteRequest.path)
+                .isEqualTo("/rpm-nightly/centos/6/x86_64/Packages/adoptopenjdk-12-hotspot-12.0.1+12-1.x86_64.rpm")
+        assertThat(firstDeleteRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        RecordedRequest secondDeleteRequest = this.mws.takeRequest()
+
+        assertThat(secondDeleteRequest.path)
+                .isEqualTo("/rpm-nightly/centos/7/x86_64/Packages/adoptopenjdk-12-hotspot-12.0.1+12-1.x86_64.rpm")
+        assertThat(secondDeleteRequest.headers.get("Authorization"))
+                .isEqualTo(Credentials.basic("aUser", "aKey"))
+
+        assertThat(result.task(":removeRpmNightlyBuilds").outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}

--- a/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/AbstractUploadLinuxPackage.java
+++ b/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/AbstractUploadLinuxPackage.java
@@ -15,7 +15,7 @@ public abstract class AbstractUploadLinuxPackage extends DefaultTask {
 
     private File packageToPublish;
 
-    private String apiEndpoint = "https://adoptopenjdk.jfrog.io/artifactory";
+    private String apiEndpoint = "https://adoptopenjdk.jfrog.io/adoptopenjdk";
 
     private String user;
 

--- a/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/RemoveObsoletePackages.java
+++ b/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/RemoveObsoletePackages.java
@@ -1,0 +1,121 @@
+package net.adoptopenjdk.installer;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.jfrog.artifactory.client.Artifactory;
+import org.jfrog.artifactory.client.ArtifactoryClientBuilder;
+import org.jfrog.artifactory.client.model.RepoPath;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class RemoveObsoletePackages extends DefaultTask {
+
+    private String apiEndpoint = "https://adoptopenjdk.jfrog.io/adoptopenjdk";
+
+    private String user;
+
+    private String password;
+
+    private String repository;
+
+    private int daysToKeep;
+
+    private Clock clock = Clock.systemUTC();
+
+    public RemoveObsoletePackages() {
+        setGroup("upload");
+        setDescription("Removes old packages");
+    }
+
+    @Input
+    @Optional
+    public String getApiEndpoint() {
+        return apiEndpoint;
+    }
+
+    public void setApiEndpoint(String apiEndpoint) {
+        this.apiEndpoint = apiEndpoint;
+    }
+
+    @Input
+    @Optional
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    @Input
+    @Optional
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Input
+    public String getRepository() {
+        return repository;
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
+    @Input
+    public int getDaysToKeep() {
+        return daysToKeep;
+    }
+
+    public void setDaysToKeep(int daysToKeep) {
+        this.daysToKeep = daysToKeep;
+    }
+
+    @Internal("for testing purposes")
+    public Clock getClock() {
+        return clock;
+    }
+
+    public void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    @TaskAction
+    public void exec() {
+        Artifactory artifactory = ArtifactoryClientBuilder.create()
+                .setUrl(getApiEndpoint())
+                .setUsername(getUser())
+                .setPassword(getPassword())
+                .build();
+
+        List<RepoPath> paths = artifactory.searches()
+                .repositories(this.repository)
+                .artifactsCreatedInDateRange(0, maximumAgeMillis())
+                .doSearch();
+
+        for (RepoPath path : paths) {
+            if (!path.getItemPath().endsWith(".deb") && !path.getItemPath().endsWith(".rpm")) {
+                continue;
+            }
+
+            getLogger().lifecycle("Removing {} from {}.", path.getRepoKey(), path.getItemPath());
+            artifactory.repository(path.getRepoKey()).delete(path.getItemPath());
+        }
+
+        getLogger().lifecycle("All obsolete packages removed from repository {}.", this.getRepository());
+    }
+
+    private long maximumAgeMillis() {
+        return Instant.now(getClock()).minus(getDaysToKeep(), ChronoUnit.DAYS).toEpochMilli();
+    }
+}

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -1,5 +1,6 @@
 import net.adoptopenjdk.installer.BuildDebianPackage
 import net.adoptopenjdk.installer.UploadDebianPackage
+import net.adoptopenjdk.installer.RemoveObsoletePackages
 
 ext.jinfoPriorities = [
     8 : 1081,
@@ -63,3 +64,13 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
 }
 
 rootProject.tasks.getByName("upload").dependsOn(uploadDebianPackage)
+
+tasks.register("cleanupDebianNightlyBuilds", RemoveObsoletePackages) {
+    apiEndpoint = artifactory.url
+    user = artifactory.user
+    password = artifactory.password
+    repository = artifactory.repository.deb
+    daysToKeep = 7
+}
+
+rootProject.tasks.getByName("cleanupNightlyBuilds").dependsOn(cleanupDebianNightlyBuilds)

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -1,4 +1,5 @@
 import net.adoptopenjdk.installer.BuildRpmPackage
+import net.adoptopenjdk.installer.RemoveObsoletePackages
 import net.adoptopenjdk.installer.UploadRpmPackage
 
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
@@ -112,6 +113,16 @@ tasks.register("uploadRpmPackage") {
 }
 
 rootProject.tasks.getByName("upload").dependsOn(uploadRpmPackage)
+
+tasks.register("cleanupRpmNightlyBuilds", RemoveObsoletePackages) {
+    apiEndpoint = artifactory.url
+    user = artifactory.user
+    password = artifactory.password
+    repository = artifactory.repository.rpm
+    daysToKeep = 7
+}
+
+rootProject.tasks.getByName("cleanupNightlyBuilds").dependsOn(cleanupRpmNightlyBuilds)
 
 def getSignPackageProperty() {
     return hasProperty("SIGN_PACKAGE") ? Boolean.parseBoolean(SIGN_PACKAGE) : true


### PR DESCRIPTION
The preconfigured tasks remove all artifacts that are older than 7 days.

Invoke with `./gradlew cleanupNightlyBuilds`. It requires the usual properties:

```
ARTIFACTORY_USER=
ARTIFACTORY_PASSWORD=
ARTIFACTORY_REPOSITORY_DEB=deb-nightly
ARTIFACTORY_REPOSITORY_RPM=rpm-nightly
```
