### PR TITLE
fix path for jvm.dll

### DIFF
--- a/wix/Includes/OpenJDK.Variables.wxi
+++ b/wix/Includes/OpenJDK.Variables.wxi
@@ -51,6 +51,24 @@
       <?define OracleJavasoftBaseKey="Java Development Kit" ?>
     <?endif?>    
   <?endif?>
+  
+  <!-- cf https://github.com/AdoptOpenJDK/openjdk-installer/issues/137 -->
+  <?if $(env.PRODUCT_CATEGORY)="jre"?>
+    <?if $(var.ProductMajorVersion)>=9?>
+        <!-- Prefere Server JVM in Java 9+ x64 -->
+        <?define DllPath="bin/server/jvm.dll" ?>
+    <?else?>
+        <!-- Java 1.8 -->
+        <?if $(env.PLATFORM)="x86"?>
+          <!-- if x86 then client jvm -->
+          <?define DllPath="bin/client/jvm.dll" ?>
+        <?else?>
+          <!-- if x64 then server jvm -->
+          <?define DllPath="bin/server/jvm.dll" ?>
+        <?endif?>
+    <?endif?>
+  <?endif?>
+  
   <!-- Static settings, DO NOT TOUCH or upgrades will break! -->
   <?define RTMProductVersion="1.0.0" ?>
 </Include>

--- a/wix/Main.hotspot.wxs
+++ b/wix/Main.hotspot.wxs
@@ -13,6 +13,7 @@
     <Property Id="ARPPRODUCTICON" Value="logo.ico" />
     <Property Id="ORACLE_VERSION_KEY" Value="$(var.OracleVersionKey)" />
     <Property Id="ORACLE_JAVASOFT_BASE_KEY" Value="$(var.OracleJavasoftBaseKey)" />
+    <Property Id="DLL_PATH" Value="$(var.DllPath)" />
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />
     <Icon Id="logo.ico" SourceFile="$(var.SetupResourcesDir)\logo.ico" />
 
@@ -132,19 +133,13 @@
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]" Name="CurrentVersion" Type="string" Value="[ORACLE_VERSION_KEY]" KeyPath="yes" />
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="JavaHome" Type="string" Value="[INSTALLDIR]" KeyPath="no" />
         <?if $(env.PRODUCT_CATEGORY)="jre"?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]bin\server\jvm.dll" KeyPath="no" />
-        <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE
-        <?else?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]jre\bin\server\jvm.dll" KeyPath="no" />
-        -->
+            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR][DLL_PATH]" KeyPath="no" />
+            <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE so no ?else? -->
         <?endif?>
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="JavaHome" Type="string" Value="[INSTALLDIR]" KeyPath="no" />
         <?if $(env.PRODUCT_CATEGORY)="jre"?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]bin\server\jvm.dll" KeyPath="no" />
-        <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE
-        <?else?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]jre\bin\server\jvm.dll" KeyPath="no" />
-        -->
+            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR][DLL_PATH]" KeyPath="no" />
+            <!-- Oracle don't set RuntimeLib for JDK .. because JRE is "private" JRE so no ?else? -->
         <?endif?>
       </Component>
       <!-- Add jnlp launch by double click -->

--- a/wix/Main.openj9.wxs
+++ b/wix/Main.openj9.wxs
@@ -13,6 +13,7 @@
     <Property Id="ARPPRODUCTICON" Value="logo.ico" />
     <Property Id="ORACLE_VERSION_KEY" Value="$(var.OracleVersionKey)" />
     <Property Id="ORACLE_JAVASOFT_BASE_KEY" Value="$(var.OracleJavasoftBaseKey)" />
+    <Property Id="DLL_PATH" Value="bin\server\jvm.dll" />
     <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />
     <Icon Id="logo.ico" SourceFile="$(var.SetupResourcesDir)\logo.ico" />
 
@@ -132,19 +133,13 @@
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]" Name="CurrentVersion" Type="string" Value="[ORACLE_VERSION_KEY]" KeyPath="yes" />
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="JavaHome" Type="string" Value="[INSTALLDIR]" KeyPath="no" />
         <?if $(env.PRODUCT_CATEGORY)="jre"?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]bin\jvm.dll" KeyPath="no" />
-        <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE
-        <?else?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]jre\bin\jvm.dll" KeyPath="no" />
-        -->
+            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\[ORACLE_VERSION_KEY]" Name="RuntimeLib" Type="string" Value="[INSTALLDIR][DLL_PATH]" KeyPath="no" />
+            <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE so no ?else? -->
         <?endif?>
         <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="JavaHome" Type="string" Value="[INSTALLDIR]" KeyPath="no" />
         <?if $(env.PRODUCT_CATEGORY)="jre"?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]bin\jvm.dll" KeyPath="no" />
-        <!-- Oracle dont set RuntimeLib for JDK .. because JRE is "private" JRE
-        <?else?>
-            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR]jre\bin\jvm.dll" KeyPath="no" />
-        -->
+            <RegistryValue Root="HKLM" Key="SOFTWARE\JavaSoft\[ORACLE_JAVASOFT_BASE_KEY]\$(var.ProductVersion)" Name="RuntimeLib" Type="string" Value="[INSTALLDIR][DLL_PATH]" KeyPath="no" />
+            <!-- Oracle don't set RuntimeLib for JDK .. because JRE is "private" JRE so no ?else? -->
         <?endif?>
       </Component>
       <!-- Add jnlp launch by double click -->


### PR DESCRIPTION
fix hotspot as discuted in https://github.com/AdoptOpenJDK/openjdk-installer/issues/137
fix for openj9 too wich has changed from bin\jvm.dll to bin\server\jvm.dll

closes: https://github.com/AdoptOpenJDK/openjdk-installer/issues/137