### PR TITLE
add notarization to installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Thumbs.db
 .idea
 *.iml
 
+node_modules/

--- a/pkgbuild/notarize/notarize.js
+++ b/pkgbuild/notarize/notarize.js
@@ -1,0 +1,34 @@
+const { notarize } = require('electron-notarize')
+const flags = require('flags');
+
+flags.defineString('appBundleId');
+flags.defineString('appPath');
+
+flags.parse();
+
+if (!flags.get('appBundleId')) {
+  console.error('please pass --appBundleId net.adoptopenjdk.11.jdk')
+  process.exit(1)
+}
+
+if (!flags.get('appPath')) {
+  console.error('please pass --appPath /path/to/installer.pkg')
+  process.exit(1)
+}
+
+let appBundleId = flags.get('appBundleId')
+let appPath = flags.get('appPath')
+let appleId = process.env.appleId
+let appleIdPassword = process.env.appleIdPassword
+
+async function packageTask () {
+  // Package your app here, and code side with hardened runtime
+  await notarize({
+    appBundleId,
+    appPath,
+    appleId,
+    appleIdPassword,
+  });
+}
+
+packageTask()

--- a/pkgbuild/notarize/package.json
+++ b/pkgbuild/notarize/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "adoptopenjdk-notarize",
+  "version": "1.0.0",
+  "description": "",
+  "main": "notarize.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "electron-notarize": "^0.1.1",
+    "flags": "^0.1.3"
+  }
+}

--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -74,7 +74,7 @@ case $INPUT_DIRECTORY in
     TYPE="jdk"
     ;;
 esac
-    
+
 # Plist commands:
 case $JVM in
   openj9)
@@ -126,3 +126,15 @@ cat distribution.xml.tmpl  \
 /usr/bin/productbuild --distribution distribution.xml --resources Resources --sign "${SIGN}" --package-path OpenJDK.pkg ${OUTPUT_DIRECTORY}
 
 rm -rf OpenJDK.pkg
+
+# Skip this on 8 until we can produce a hardened runtime
+if [ "$MAJOR_VERSION" != 8 ]; then
+  echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
+  sudo xcode-select --switch /Applications/Xcode.app
+  cd $WORKSPACE/pkgbuild/notarize
+  npm install
+  node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
+  # Validates that the app has been notarized
+  spctl -a -v --type install ${OUTPUT_DIRECTORY}
+  cd $WORKSPACE
+fi


### PR DESCRIPTION
closes: https://github.com/AdoptOpenJDK/openjdk-installer/issues/145

This PR enables our installers to be notarized to meet Apple's new requirements for 10.14.5 and above.