### PR TITLE
Add enough Xs to mktemp

### DIFF
--- a/linux/create_installer_linux.sh
+++ b/linux/create_installer_linux.sh
@@ -42,6 +42,7 @@ if [ -z "${ARTIFACTORY_USER+x}" ]; then
     ARTIFACTORY_USER="adoptopenjdk-jenkins-bot"
 fi
 
+# Need the XXXXXX else the template complains it doesn't have them
 DISTRIBUTION_DIR=$(mktemp -d -t adoptjdkbuild.XXXXXX)
 
 finish() {

--- a/linux/create_installer_linux.sh
+++ b/linux/create_installer_linux.sh
@@ -42,7 +42,7 @@ if [ -z "${ARTIFACTORY_USER+x}" ]; then
     ARTIFACTORY_USER="adoptopenjdk-jenkins-bot"
 fi
 
-DISTRIBUTION_DIR=$(mktemp -d -t adoptjdkbuild)
+DISTRIBUTION_DIR=$(mktemp -d -t adoptjdkbuild.XXXXXX)
 
 finish() {
     if [ -d "$DISTRIBUTION_DIR" ] ; then


### PR DESCRIPTION
The build is currently failing with `mktemp: too few X's in template ‘adoptjdkbuild’`.