### PR TITLE
Remove illegal chars from metadata version only

### DIFF
--- a/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/AbstractBuildLinuxPackage.java
+++ b/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/AbstractBuildLinuxPackage.java
@@ -25,7 +25,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -329,41 +328,7 @@ public abstract class AbstractBuildLinuxPackage extends DefaultTask {
         this.variant = variant;
     }
 
-    List<String> fpmArguments() {
-        List<String> arguments = new ArrayList<>();
-
-        arguments.add("--input-type=dir");
-        arguments.add(String.format("--output-type=%s", getPackageType()));
-        arguments.add(String.format("--package=%s", getOutputFile()));
-        arguments.add(String.format("--name=%s", getPackageName()));
-        arguments.add(String.format("--version=%s", getPackageVersion()));
-        arguments.add(String.format("--iteration=%s", getIteration()));
-        arguments.add(String.format("--category=%s", getCategory()));
-        arguments.add(String.format("--prefix=%s", getPrefix()));
-        arguments.add(String.format("--maintainer=%s", getMaintainer()));
-        arguments.add(String.format("--license=%s", getLicense()));
-        arguments.add(String.format("--url=%s", getHomepage()));
-        arguments.add(String.format("--description=%s", getPackageDescription()));
-        arguments.add(String.format("--vendor=%s", getVendor()));
-        arguments.add(String.format("--chdir=%s", getTemporaryDir()));
-
-        if (getAfterInstallScript() != null) {
-            arguments.add(String.format("--after-install=%s",
-                    new File(getProject().getBuildDir(), getAfterInstallScript().getName())));
-        }
-        if (getBeforeRemoveScript() != null) {
-            arguments.add(String.format("--before-remove=%s",
-                    new File(getProject().getBuildDir(), getBeforeRemoveScript().getName())));
-        }
-        for (String dependency : collectDependencies()) {
-            arguments.add(String.format("--depends=%s", dependency));
-        }
-        for (String providesEntry : collectProvides()) {
-            arguments.add(String.format("--provides=%s", providesEntry));
-        }
-
-        return arguments;
-    }
+    abstract List<String> fpmArguments();
 
     abstract Map<String, Object> templateContext();
 

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -12,7 +12,7 @@ ext.jinfoPriorities = [
 
 tasks.register("buildDebianPackage", BuildDebianPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
-    packageVersion = cleanPackageVersion(jdkVersion)
+    packageVersion = jdkVersion
     iteration = 2
     priority = jinfoPriorities[jdkMajorVersion]
     architecture = pkgMetadata.architecture
@@ -68,8 +68,3 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
 }
 
 rootProject.tasks.getByName("upload").dependsOn(uploadDebianPackage)
-
-def cleanPackageVersion(String jdkVersion) {
-    // Underscores are reserved characters in Deb packages
-    return jdkVersion.replaceAll("[_]", "-")
-}

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -3,7 +3,7 @@ import net.adoptopenjdk.installer.UploadRpmPackage
 
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
-    packageVersion = cleanPackageVersion(jdkVersion)
+    packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture
     vm = pkgMetadata.vm
@@ -25,7 +25,7 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
 
 tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
-    packageVersion = cleanPackageVersion(jdkVersion)
+    packageVersion = jdkVersion
     iteration = version
     architecture = pkgMetadata.architecture
     vm = pkgMetadata.vm
@@ -117,9 +117,4 @@ rootProject.tasks.getByName("upload").dependsOn(uploadRpmPackage)
 
 def getSignPackageProperty() {
     return hasProperty("SIGN_PACKAGE") ? Boolean.parseBoolean(SIGN_PACKAGE) : true
-}
-
-def cleanPackageVersion(String jdkVersion) {
-    // Dashes are reserved characters in RPMs
-    return jdkVersion.replaceAll("[\\-]", "_")
 }


### PR DESCRIPTION
I made a mistake in #141 by replacing illegal characters in filenames, too, and not only in the metadata. Only RPMs were affected, producing files like `adoptopenjdk-8-openj9-8u222_b10.openj9_0.15.1-1.x86_64.rpm` instead of `adoptopenjdk-8-openj9-8u222-b10.openj9-0.15.1-1.x86_64.rpm` (`_` instead of `-` after `8u222` and `openj9`).