### PR TITLE
re enable notarization

### DIFF
--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -132,10 +132,8 @@ rm -rf OpenJDK.pkg
 #if [ "$MAJOR_VERSION" != 8 ]; then
 echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
 sudo xcode-select --switch /Applications/Xcode.app || true
-cd $WORKSPACE/pkgbuild/notarize
 npm install
 node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
 # Validates that the app has been notarized
 spctl -a -v --type install ${OUTPUT_DIRECTORY}
-cd $WORKSPACE
 #fi

--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -132,8 +132,10 @@ rm -rf OpenJDK.pkg
 #if [ "$MAJOR_VERSION" != 8 ]; then
 echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
 sudo xcode-select --switch /Applications/Xcode.app || true
+cd notarize
 npm install
 node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
 # Validates that the app has been notarized
 spctl -a -v --type install ${OUTPUT_DIRECTORY}
+cd -
 #fi

--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -131,7 +131,7 @@ rm -rf OpenJDK.pkg
 # Skip this on 8 until we can produce a hardened runtime
 #if [ "$MAJOR_VERSION" != 8 ]; then
 echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
-sudo xcode-select --switch /Applications/Xcode.app
+sudo xcode-select --switch /Applications/Xcode.app || true
 cd $WORKSPACE/pkgbuild/notarize
 npm install
 node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}

--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -130,12 +130,12 @@ rm -rf OpenJDK.pkg
 # TODO Bring this back pending resolution to https://github.com/AdoptOpenJDK/TSC/issues/107
 # Skip this on 8 until we can produce a hardened runtime
 #if [ "$MAJOR_VERSION" != 8 ]; then
-#  echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
-#  sudo xcode-select --switch /Applications/Xcode.app
-#  cd $WORKSPACE/pkgbuild/notarize
-#  npm install
-#  node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
-#  # Validates that the app has been notarized
-#  spctl -a -v --type install ${OUTPUT_DIRECTORY}
-#  cd $WORKSPACE
+echo "Notarizing the installer (please be patient! this takes aprox 10 minutes)"
+sudo xcode-select --switch /Applications/Xcode.app
+cd $WORKSPACE/pkgbuild/notarize
+npm install
+node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
+# Validates that the app has been notarized
+spctl -a -v --type install ${OUTPUT_DIRECTORY}
+cd $WORKSPACE
 #fi


### PR DESCRIPTION
while apple has temporarily made notarization easier (https://developer.apple.com/news/?id=09032019a) we can continue as before without hardened runtime enabled.