### PR TITLE
Add support for Fedora 31, drop Fedora 29

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -62,6 +62,7 @@ Table with arguments:
 | JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 | JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 | JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
+| JDK 13 | 13                  | e.g. `13.0.1+9`  | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 
 ### RPM packages
 
@@ -100,6 +101,7 @@ Example:
 | JDK 10 | 10                  | e.g. `10.0.2+13` | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 | JDK 11 | 11                  | e.g. `11.0.2+9`  | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 | JDK 12 | 12                  | e.g. `12.0.1+12` | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
+| JDK 13 | 13                  | e.g. `13.0.1+9`  | `hotspot`, `openj9`, `openj9_xl` | `x64`, `s390x`, `ppc64le`, `arm`, `aarch64` |
 
 RPMs are automatically signed if `SIGN_PACKAGE` is set to `true`. Signing requires the file  `~/.rpmmacros` to be present with the following signing configuration (change values as necessary):
 
@@ -142,6 +144,7 @@ All packages can be installed on Debian, Raspbian (armhf/arm64 only) and Ubuntu 
 | JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
 | JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
 | JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
+| JDK 13 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
 
 * [Debian releases and support timeframe](https://wiki.debian.org/DebianReleases)
 * [Ubuntu releases and support timeframe](https://wiki.ubuntu.com/Releases)
@@ -157,6 +160,7 @@ All packages can be installed on Amazon Linux, CentOS, Fedora, Red Hat Enterpris
 | JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
 | JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
 | JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 13 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
 
 * Amazon Linux releases and support timeframe: [Amazon Linux 1](https://aws.amazon.com/de/amazon-linux-ami/faqs/#how_long), [Amazon Linux 2](https://aws.amazon.com/de/amazon-linux-2/faqs/#Long_Term_Support) 
 * [CentOS releases and support timeframe](https://wiki.centos.org/Download)

--- a/linux/README.md
+++ b/linux/README.md
@@ -152,11 +152,11 @@ All packages can be installed on Amazon Linux, CentOS, Fedora, Red Hat Enterpris
 
 | OpenJDK                  | Amazon  | CentOS  | Fedora | RHEL    | OpenSUSE   | SLES   |
 |--------------------------|---------|---------|--------|---------|------------|--------|
-| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 29, 30 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
 
 * Amazon Linux releases and support timeframe: [Amazon Linux 1](https://aws.amazon.com/de/amazon-linux-ami/faqs/#how_long), [Amazon Linux 2](https://aws.amazon.com/de/amazon-linux-2/faqs/#Long_Term_Support) 
 * [CentOS releases and support timeframe](https://wiki.centos.org/Download)

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -65,7 +65,7 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
         amazonlinux: ["1", "2"],
         centos     : ["6", "7", "8"],
         rhel       : ["6", "7", "8"],
-        fedora     : ["29", "30"]
+        fedora     : ["30", "31"]
     ]
     releaseArchitecture s390x: [
         centos: ["6", "7", "8"],


### PR DESCRIPTION
Plus the addition of JDK 13 to the support matrix that was previously undocumented because I forgot to do it.