### PR TITLE
Add support to disable macOS signing

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -27,8 +27,15 @@ if [ ! -z "$CERTIFICATE" ]; then
 fi
 set -u
 
+set +u
+SEARCH_PATTERN=
+if [ -z "$SEARCH_PATTERN" ]; then
+  SEARCH_PATTERN=OpenJDK*-j*.tar.gz
+fi
+set -u
+
 cd pkgbuild
-for f in $WORKSPACE/workspace/target/*.tar.gz;
+for f in $WORKSPACE/workspace/target/${SEARCH_PATTERN};
 do tar -xf "$f";
   rm -rf Resources/license.rtf
 

--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -20,8 +20,15 @@ if [ -f ~/.password ]; then
   security unlock-keychain -p `cat ~/.password`
 fi
 
+set +u
+SIGN_OPTION=
+if [ ! -z "$CERTIFICATE" ]; then
+  SIGN_OPTION="--sign ${CERTIFICATE}"
+fi
+set -u
+
 cd pkgbuild
-for f in $WORKSPACE/workspace/target/OpenJDK*-j*.tar.gz;
+for f in $WORKSPACE/workspace/target/*.tar.gz;
 do tar -xf "$f";
   rm -rf Resources/license.rtf
 
@@ -38,6 +45,9 @@ do tar -xf "$f";
 
   directory=$(ls -d jdk*)
   file=${f%%.tar.gz*}
-  ./pkgbuild.sh --sign "${CERTIFICATE}" --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg
+
+  ./pkgbuild.sh ${SIGN_OPTION} --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg
+
   rm -rf ${directory}
+  rm -rf ${f}
 done

--- a/pkgbuild/pkgbuild.sh
+++ b/pkgbuild/pkgbuild.sh
@@ -17,6 +17,7 @@
 set -eu
 
 SIGN_OPTION=
+NOTARIZE_OPTION=
 
 while test $# -gt 0; do
   case "$1" in
@@ -53,6 +54,7 @@ while test $# -gt 0; do
     -s|--sign)
       shift
       SIGN_OPTION="--sign $1"
+      NOTARIZE_OPTION="true"
       shift
       ;;
     *)
@@ -129,7 +131,7 @@ cat distribution.xml.tmpl  \
 
 rm -rf OpenJDK.pkg
 
-if [ ! -z "$SIGN_OPTION" ]; then
+if [ ! -z "$NOTARIZE_OPTION" ]; then
   # TODO Bring this back pending resolution to https://github.com/AdoptOpenJDK/TSC/issues/107
   # Skip this on 8 until we can produce a hardened runtime
   #if [ "$MAJOR_VERSION" != 8 ]; then


### PR DESCRIPTION
Build the macOS installer when `CERTIFICATE` is not set. User can add their own customized steps to sign the macOS package.