### PR TITLE
Update supported distributions

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -141,16 +141,16 @@ By specifying all build properties (see above) building and uploading can be don
 
 All packages can be installed on Debian, Raspbian (armhf/arm64 only) and Ubuntu without further changes. They are available for amd64, s390x, ppc64el, armhf and arm64 unless otherwise noted. All major versions as well as JDKs and JREs can be installed side by side. JDKs and JREs have no dependencies on each other and are completely self-contained.
 
-| OpenJDK                  | Debian                               | Ubuntu                                                      |
-|--------------------------|--------------------------------------|-------------------------------------------------------------|
-| JDK 8 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 9 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 13 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 14 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
-| JDK 15 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan) |
+| OpenJDK                  | Debian                               | Ubuntu                                                                     |
+|--------------------------|--------------------------------------|----------------------------------------------------------------------------|
+| JDK 8 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 9 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 13 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 14 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
+| JDK 15 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.04 (disco), 19.10 (eoan), 20.04 (focal) |
 
 * [Debian releases and support timeframe](https://wiki.debian.org/DebianReleases)
 * [Ubuntu releases and support timeframe](https://wiki.ubuntu.com/Releases)
@@ -159,16 +159,16 @@ All packages can be installed on Debian, Raspbian (armhf/arm64 only) and Ubuntu 
 
 All packages can be installed on Amazon Linux, CentOS, Fedora, Red Hat Enterprise Linux (RHEL) as well as OpenSUSE and SUSE Enterprise Linux (SLES) without further changes. All major versions as well as JDKs and JREs can be installed side by side. JDKs and JREs have no dependencies on each other and are completely self-contained. Packages for Amazon Linux 1, Fedora and OpenSUSE are only available for x86_64. Amazon Linux 2 supports aarch64, too. The packages for all other distributions are available for x86_64, s390x, ppc64le and aarch64.
 
-| OpenJDK                  | Amazon  | CentOS  | Fedora | RHEL    | OpenSUSE   | SLES   |
-|--------------------------|---------|---------|--------|---------|------------|--------|
-| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 13 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 14 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
-| JDK 15 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31 | 6, 7, 8 | 15.0, 15.1 | 12, 15 |
+| OpenJDK                  | Amazon  | CentOS  | Fedora     | RHEL    | OpenSUSE   | SLES   |
+|--------------------------|---------|---------|------------|---------|------------|--------|
+| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 13 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 14 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 15 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 30, 31, 32 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
 
 * Amazon Linux releases and support timeframe: [Amazon Linux 1](https://aws.amazon.com/de/amazon-linux-ami/faqs/#how_long), [Amazon Linux 2](https://aws.amazon.com/de/amazon-linux-2/faqs/#Long_Term_Support)
 * [CentOS releases and support timeframe](https://wiki.centos.org/Download)

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -49,23 +49,23 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
     architecture = buildDebianPackage.getArchitecture().debQualifier()
     releaseArchitecture amd64: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "disco", "eoan"]
+        ubuntu: ["xenial", "bionic", "disco", "eoan", "focal"]
     ]
     releaseArchitecture s390x: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "disco", "eoan"]
+        ubuntu: ["xenial", "bionic", "disco", "eoan", "focal"]
     ]
     releaseArchitecture ppc64el: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "disco", "eoan"]
+        ubuntu: ["xenial", "bionic", "disco", "eoan", "focal"]
     ]
     releaseArchitecture armhf: [
         debian  : ["jessie", "stretch", "buster"],
-        ubuntu  : ["xenial", "bionic", "disco", "eoan"]
+        ubuntu  : ["xenial", "bionic", "disco", "eoan", "focal"]
     ]
     releaseArchitecture arm64: [
         debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "disco", "eoan"]
+        ubuntu: ["xenial", "bionic", "disco", "eoan", "focal"]
     ]
 }
 

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -65,7 +65,7 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
         amazonlinux: ["1", "2"],
         centos     : ["6", "7", "8"],
         rhel       : ["6", "7", "8"],
-        fedora     : ["30", "31"]
+        fedora     : ["30", "31", "32"]
     ]
     releaseArchitecture s390x: [
         centos: ["6", "7", "8"],
@@ -93,7 +93,7 @@ tasks.register("uploadSuseRpmPackage", UploadRpmPackage) {
     packageName = buildSuseRpmPackage.getPackageName()
     architecture = buildSuseRpmPackage.getArchitecture().rpmQualifier()
     releaseArchitecture x86_64: [
-        opensuse: ["15.0", "15.1"],
+        opensuse: ["15.1", "15.2"],
         sles    : ["12", "15"]
     ]
     releaseArchitecture s390x: [


### PR DESCRIPTION
* Ubuntu: Add upcoming Ubuntu 20.04.
* Fedora: Add upcoming Fedora 32.
* OpenSUSE: Drop OpenSUSE 15.0 (EOL 2019-11), add upcoming OpenSUSE 15.2.