### PR TITLE
Add temporary workaround for OpenJ9 URL change

### DIFF
--- a/linux/standalone_create_installer_linux.sh
+++ b/linux/standalone_create_installer_linux.sh
@@ -47,7 +47,13 @@ shopt -s globstar nullglob nocaseglob nocasematch
 
 for DISTRIBUTION_TYPE in "jdk" "jre" ; do
     for ARCHITECTURE in "x64" "s390x" "ppc64le" "arm" "aarch64" ; do
-        JDK_FILENAME="OpenJDK${MAJOR_VERSION}U-${DISTRIBUTION_TYPE}_${ARCHITECTURE}_linux_${JVM}_${SUB_TAG}.tar.gz"
+        # Temporary workaround for release of 14+36
+        if [ "$JVM" == "hotspot" ] ; then
+            JDK_FILENAME="OpenJDK${MAJOR_VERSION}U-${DISTRIBUTION_TYPE}_${ARCHITECTURE}_linux_${JVM}_${SUB_TAG}.tar.gz"
+        else
+            JDK_FILENAME="OpenJDK${MAJOR_VERSION}-${DISTRIBUTION_TYPE}_${ARCHITECTURE}_linux_${JVM}_${SUB_TAG}.tar.gz"
+        fi
+
         DOWNLOAD_URL="https://github.com/AdoptOpenJDK/openjdk${MAJOR_VERSION}-binaries/releases/download/${TAG}/${JDK_FILENAME}"
 
         # Script should continue even if the file cannot be downloaded because


### PR DESCRIPTION
The download URLs look different for OpenJ9 14+36 than they do for other releases. This workaround handles it for the release of 14+36. Will revert afterwards (or even better, migrate to a more stable solution).