### PR TITLE
Account for JDK-Next Binaries

### DIFF
--- a/wix/SourceDir/CreateSourceFolder.AdoptOpenJDK.ps1
+++ b/wix/SourceDir/CreateSourceFolder.AdoptOpenJDK.ps1
@@ -1,6 +1,6 @@
 Get-ChildItem -Path .\ -Filter *.zip -File -Name| ForEach-Object {
   $filename = [System.IO.Path]::GetFileName($_)
-  $jdk_version_found = $filename -match "(?<jdk>^OpenJDK\d+)"
+  $jdk_version_found = $filename -match "(?<jdk>^(?:OpenJDK\d+|OpenJDK))"
   if (!$jdk_version_found) {
     echo "filename : $filename don't match regex ^OpenJDK\d+"
     exit 2


### PR DESCRIPTION
* JDK-NEXT tarballs have no major version number in name

Closes: https://github.com/AdoptOpenJDK/openjdk-build/issues/1712
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>