### PR TITLE
Manage unzip of JDK-Latest without number in file name

### DIFF
--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -118,10 +118,18 @@ FOR %%A IN (%ARCH%) DO (
 				)
 				IF NOT EXIST "!REPRO_DIR!" (
 					ECHO Third !REPRO_DIR! not exists
-					ECHO SOURCE Dir not found / failed
-					ECHO Listing directory :
-					dir /a:d /s /b /o:n SourceDir
-					GOTO FAILED
+					REM try folder for JDK-Latest defined in CreateSourceFolder.AdoptOpenJDK.ps1
+					SET REPRO_DIR=.\SourceDir\!PRODUCT_SKU!-Latest\!PACKAGE_TYPE!\!FOLDER_PLATFORM!\jdk-%PRODUCT_MAJOR_VERSION%.%PRODUCT_MINOR_VERSION%.%PRODUCT_MAINTENANCE_VERSION%+%PRODUCT_PATCH_VERSION%
+					IF !PRODUCT_CATEGORY! == jre (
+						SET REPRO_DIR=!REPRO_DIR!-!PRODUCT_CATEGORY!
+					)
+					IF NOT EXIST "!REPRO_DIR!" (
+						ECHO OpenJDK-Latest unnumbered !REPRO_DIR! does not exist
+						ECHO SOURCE Dir not found / failed
+						ECHO Listing directory :
+						dir /a:d /s /b /o:n SourceDir
+						GOTO FAILED
+					)
 				)
 			)
 		)


### PR DESCRIPTION
Ready to work with artifact OpenJDK_*.zip without major number as we get major java version in job parameter.
All unnumbered (major) zip file is now unzip in a folder "OpenJDK-Latest"

https://github.com/AdoptOpenJDK/openjdk-build/pull/1764 is no longer needed for Windows installer.
Fix : https://github.com/AdoptOpenJDK/openjdk-build/issues/1712

Need also a revert or fix from https://github.com/AdoptOpenJDK/openjdk-build/pull/1754 to return back to normal

This https://github.com/AdoptOpenJDK/openjdk-build/issues/1751 is still relevant
and match the JRE|JDK part of https://github.com/AdoptOpenJDK/openjdk-installer/issues/211