### PR TITLE
Add RISCV support

### DIFF
--- a/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/Architecture.java
+++ b/linux/buildSrc/src/main/java/net/adoptopenjdk/installer/Architecture.java
@@ -9,6 +9,7 @@ package net.adoptopenjdk.installer;
 public enum Architecture {
     X64("amd64", "x86_64", 64),
     S390X("s390x", "s390x", 64),
+    RISCV64("riscv64", "riscv64", 64),
     PPC64LE("ppc64el", "ppc64le", 64),
     ARM("armhf", "armhfp", 32),
     AARCH64("arm64", "aarch64", 64);


### PR DESCRIPTION
This will likely fail at present due to the build pipelines being `riscv` instead of `riscv64` but that is being addressed under a separate PR.

Fixes https://github.com/AdoptOpenJDK/openjdk-installer/issues/213

At the moment I don't have a Debian system to test on, and I suspect there is no SuSE port to this platform so that is superfluous.

I have verified that the RedHat rpm produced by this will install and is runnable on my Fedora RISCV system, however it does not uninstall so further work will be required:

```
[root@stage4 /]# rpm -e adoptopenjdk-11-openj9-jre-11.0.0_internal+0_adhoc.jenkins.openj9_openjdk_jdk11-1.riscv64
error: %preun(adoptopenjdk-11-openj9-jre-11.0.0_internal+0_adhoc.jenkins.openj9_openjdk_jdk11-1.riscv64) scriptlet failed, exit status 2
error: adoptopenjdk-11-openj9-jre-11.0.0_internal+0_adhoc.jenkins.openj9_openjdk_jdk11-1.riscv64: erase failed
[root@stage4 /]# 
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>