### PR TITLE
allow any vendor to produce packages with vendor metadata and name

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -54,10 +54,44 @@ Example:
 ```
 
 #### Optional Arguments
-- `-PVENDOR=vendor_name` - Specify a custom vendor name
-- `-PVENDOR_HOMEPAGE="www.homepage.com"` - specify a custom link to vendor homepage
-- `-PVENDOR_SOURCE_URL="www.sourcecode.com"` - specify a custom link to source code
-- `-PDEBIAN_ITERATION=1` - specify the iteration
+
+* `-PPACKAGE_NAME=pkg_name` - Specify the name of the output package, defaults to `adoptopenjdk`
+* `-PVENDOR=vendor_name` - Specify a custom vendor name, defaults to `AdoptOpenJDK`
+* `-PVENDOR_HOMEPAGE="https://example.com/"` - specify a custom link to vendor homepage
+* `-PVENDOR_SOURCE_URL="https://example.com/"` - specify a custom link to source code
+* `-PDEBIAN_ITERATION=1` - specify the iteration
+
+3rd party vendors can choose to populate the above optional arguments to customize package metadata.
+
+Example:
+
+```bash
+./gradlew buildDebPackage \
+    -PJDK_DISTRIBUTION_TYPE=JDK \
+    -PPACKAGE_NAME=openjdk \
+    -PVENDOR=Vendor \
+    -PVENDOR_HOMEPAGE="https://homepage.com" \
+    -PJDK_DISTRIBUTION_DIR=path-to/jdk-11.0.8+2 \
+    -PJDK_MAJOR_VERSION=11 \
+    -PJDK_VERSION=11.0.8+2~vendor \
+    -PJDK_VM=hotspot \
+    -PJDK_ARCHITECTURE=x64 \
+    -PDEBIAN_ITERATION=5
+```
+
+will produce `openjdk-11-hotspot_11.0.8+2~vendor-5_amd64.deb` with the following metadata:
+
+```
+ new Debian package, version 2.0.
+ Package: openjdk-11-hotspot
+ Version: 11.0.8+2~vendor-5
+ Vendor: Vendor
+ Maintainer: Vendor
+ Homepage: https://homepage.com
+ Description: OpenJDK Development Kit 11 (JDK) with Hotspot by Vendor
+ ...
+
+```
 
 Table with arguments:
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -53,6 +53,12 @@ Example:
     -PJDK_ARCHITECTURE=x64
 ```
 
+#### Optional Arguments
+- `-PVENDOR=vendor_name` - Specify a custom vendor name
+- `-PVENDOR_HOMEPAGE="www.homepage.com"` - specify a custom link to vendor homepage
+- `-PVENDOR_SOURCE_URL="www.sourcecode.com"` - specify a custom link to source code
+- `-PDEBIAN_ITERATION=1` - specify the iteration
+
 Table with arguments:
 
 |        | JDK\_MAJOR\_VERSION | JDK\_VERSION     | JDK\_VM                          | JDK\_ARCHITECTURE                           |

--- a/linux/README.md
+++ b/linux/README.md
@@ -61,7 +61,7 @@ Example:
 * `-PVENDOR_SOURCE_URL="https://example.com/"` - specify a custom link to source code
 * `-PDEBIAN_ITERATION=1` - specify the iteration
 
-3rd party vendors can choose to populate the above optional arguments to customize package metadata.
+3rd party vendors can choose to populate the above optional arguments to customize package metadata. Please note that vendor name should be included in the JDK_VERSION.
 
 Example:
 

--- a/linux/build.gradle
+++ b/linux/build.gradle
@@ -32,7 +32,7 @@ ext {
         vm          : getJdkVirtualMachine(),
         description : "${jdkDistributionType.description} ${jdkMajorVersion} (${jdkDistributionType.name()}) with ${getJdkVirtualMachine().description()} by ${getVendor()}",
         homepage    : getVendorHomePage(),
-        vcsUrl      : getVendorSourceURL(),
+        vcsUrl   : getVendorSourceURL(),
         debianIteration: getDebianIteration(),
         rpmIteration: getRPMIteration(),
         license     : "GPL-2.0+CE",
@@ -87,7 +87,7 @@ def getVendor() {
 }
 
 def getPackageName() {
-    return hasProperty("VENDOR") ? "openjdk" : "adoptopenjdk"
+    return hasProperty("PACKAGE_NAME") ? PACKAGE_NAME : "adoptopenjdk"
 }
 
 def getVendorHomePage() {
@@ -95,7 +95,7 @@ def getVendorHomePage() {
 }
 
 def getVendorSourceURL() {
-    return hasProperty("VENDOR_SOURCE_URL") ? VENDOR_HOMEPAGE : "https://github.com/AdoptOpenJDK/openjdk-jdk${jdkMajorVersion}u"
+    return hasProperty("VENDOR_SOURCE_URL") ? VENDOR_SOURCE_URL : "https://github.com/AdoptOpenJDK/openjdk-jdk${jdkMajorVersion}u"
 }
 
 def getJdkMajorVersion() {

--- a/linux/build.gradle
+++ b/linux/build.gradle
@@ -15,8 +15,6 @@ plugins {
 allprojects {
     apply plugin: "base"
 
-    version = 1
-
     repositories {
         mavenCentral()
     }
@@ -32,21 +30,23 @@ ext {
     pkgMetadata = [
         architecture: getJdkArchitecture(),
         vm          : getJdkVirtualMachine(),
-        description : "${jdkDistributionType.description} ${jdkMajorVersion} (${jdkDistributionType.name()}) with ${getJdkVirtualMachine().description()} by AdoptOpenJDK",
-        homepage    : "https://adoptopenjdk.net/",
-        vcsUrl      : "https://github.com/AdoptOpenJDK/openjdk-jdk${jdkMajorVersion}u",
-        iteration   : version,
+        description : "${jdkDistributionType.description} ${jdkMajorVersion} (${jdkDistributionType.name()}) with ${getJdkVirtualMachine().description()} by ${getVendor()}",
+        homepage    : getVendorHomePage(),
+        vcsUrl      : getVendorSourceURL(),
+        debianIteration: getDebianIteration(),
+        rpmIteration: getRPMIteration(),
         license     : "GPL-2.0+CE",
-        maintainer  : "AdoptOpenJDK",
-        vendor      : "AdoptOpenJDK"
+        maintainer  : getVendor(),
+        vendor      : getVendor(),
+        packageName : "${getPackageName()}-${jdkMajorVersion}-${getJdkVirtualMachine().packageQualifier}${jdkDistributionType.pkgNameSuffix}"
     ]
     artifactory = [
         url       : "https://adoptopenjdk.jfrog.io/adoptopenjdk/",
-        user      : ARTIFACTORY_USER,
-        password  : ARTIFACTORY_PASSWORD,
+        user      : hasProperty("ARTIFACTORY_USER") ? ARTIFACTORY_USER : null,
+        password  : hasProperty("ARTIFACTORY_PASSWORD") ? ARTIFACTORY_PASSWORD : null,
         repository: [
-            deb: ARTIFACTORY_REPOSITORY_DEB,
-            rpm: ARTIFACTORY_REPOSITORY_RPM
+            deb: hasProperty("ARTIFACTORY_REPOSITORY_DEB") ? ARTIFACTORY_REPOSITORY_DEB : null,
+            rpm: hasProperty("ARTIFACTORY_REPOSITORY_RPM") ? ARTIFACTORY_REPOSITORY_RPM : null,
         ],
     ]
     jdkDistributionDir = JDK_DISTRIBUTION_DIR
@@ -56,6 +56,14 @@ ext {
 tasks.register("upload") {
     group = "upload"
     description = "Uploads all linux packages"
+}
+
+def getDebianIteration () {
+    return hasProperty("DEBIAN_ITERATION") ? Integer.parseInt(DEBIAN_ITERATION) : 2
+}
+
+def getRPMIteration () {
+    return hasProperty("RPM_ITERATION") ? Integer.parseInt(RPM_ITERATION) : 1
 }
 
 def getJdkDistributionType() {
@@ -72,6 +80,22 @@ def getJdkArchitecture() {
     return hasProperty("JDK_ARCHITECTURE") ?
         Architecture.valueOf(JDK_ARCHITECTURE.toUpperCase(Locale.US)) :
         Architecture.X64
+}
+
+def getVendor() {
+    return hasProperty("VENDOR") ? VENDOR : "AdoptOpenJDK"
+}
+
+def getPackageName() {
+    return hasProperty("VENDOR") ? "openjdk" : "adoptopenjdk"
+}
+
+def getVendorHomePage() {
+    return hasProperty("VENDOR_HOMEPAGE") ? VENDOR_HOMEPAGE : "https://adoptopenjdk.net/"
+}
+
+def getVendorSourceURL() {
+    return hasProperty("VENDOR_SOURCE_URL") ? VENDOR_HOMEPAGE : "https://github.com/AdoptOpenJDK/openjdk-jdk${jdkMajorVersion}u"
 }
 
 def getJdkMajorVersion() {

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -13,9 +13,9 @@ ext.jinfoPriorities = [
 ]
 
 tasks.register("buildDebianPackage", BuildDebianPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
+    packageName = pkgMetadata.packageName
     packageVersion = jdkVersion
-    iteration = 2
+    iteration = pkgMetadata.debianIteration
     priority = jinfoPriorities[jdkMajorVersion]
     architecture = pkgMetadata.architecture
     vm = pkgMetadata.vm

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -4,7 +4,7 @@ import net.adoptopenjdk.installer.UploadRpmPackage
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
-    iteration = version
+    iteration = pkgMetadata.rpmIteration
     architecture = pkgMetadata.architecture
     vm = pkgMetadata.vm
     maintainer = pkgMetadata.maintainer
@@ -26,7 +26,7 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
 tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
     packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
     packageVersion = jdkVersion
-    iteration = version
+    iteration = pkgMetadata.rpmIteration
     architecture = pkgMetadata.architecture
     vm = pkgMetadata.vm
     maintainer = pkgMetadata.maintainer

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -2,7 +2,7 @@ import net.adoptopenjdk.installer.BuildRpmPackage
 import net.adoptopenjdk.installer.UploadRpmPackage
 
 tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
+    packageName = pkgMetadata.packageName
     packageVersion = jdkVersion
     iteration = pkgMetadata.rpmIteration
     architecture = pkgMetadata.architecture
@@ -24,7 +24,7 @@ tasks.register("buildRedHatRpmPackage", BuildRpmPackage) {
 }
 
 tasks.register("buildSuseRpmPackage", BuildRpmPackage) {
-    packageName = "adoptopenjdk-${jdkMajorVersion}-${pkgMetadata.vm.packageQualifier}${jdkDistributionType.pkgNameSuffix}"
+    packageName = pkgMetadata.packageName
     packageVersion = jdkVersion
     iteration = pkgMetadata.rpmIteration
     architecture = pkgMetadata.architecture


### PR DESCRIPTION
[UPDATED]
Will keep the same gradle task but add optional arguments to specify VENDOR, VENDOR_HOMEPAGE, VENDOR_SROURCE_URL, DEBIAN_ITERATION

**[DEPRECATED INFO BELOW]**
Proposing a new gradle task for building .deb package by any vendor

*VENDOR*:
- vendor value is passed in by providing `-PVENDOR="vendor.."` to the gradle task
- if not specified, it defaults to "AdoptOpenJDK". 

*VENDOR_HOMEPAGE*:
- homepage is passed in by providing `-PVENDOR_HOMEPAGE="www.abc.com"` to the gradle task.
- if not specified, the value defaults to "https://adoptopenjdk.net/"

*Testing Results*:
An example package is created by `./gradlew buildVendorDebPackage` with the following arguments: 
```
-PJDK_DISTRIBUTION_TYPE=JDK 
-PJDK_MAJOR_VERSION=11 
-PJDK_VERSION=11.0.8+2 
-PJDK_VM=hotspot 
-PVENDOR=Microsoft 
-PVENDOR_HOMEPAGE="www.microsoft.com" 
...
```
results in a package name of `openjdk-11-hotspot-11.0.8+2_Microsoft_amd64.deb`
and this `dpkg -I` output:
```
 new Debian package, version 2.0.
 Package: openjdk-11-hotspot
 Version: 11.0.8+2-2
 License: GPL-2.0+CE
 Vendor: Microsoft
 Architecture: amd64
 Maintainer: Microsoft
 Installed-Size: 369769
 Depends: ...
 Provides: ...
 Homepage: https://www.microsoft.com/
 Description: OpenJDK Development Kit 11 (JDK) with Hotspot by Microsoft
```

*Testing that my change is not breaking Adopt*
a package created by `./gradlew buildDebPackage` task with no vendor or vendor homepage specified, results in the pacakge name of `adoptopenjdk-11-hotspot_11.0.8+2-2_amd64.deb`
and the following`dpkg -I` output:
```
 new Debian package, version 2.0.
 Package: adoptopenjdk-11-hotspot
 Version: 11.0.8+2-2
 Vendor: AdoptOpenJDK
 Architecture: amd64
 Maintainer: AdoptOpenJDK
 Installed-Size: 369769
 Homepage: https://adoptopenjdk.net/
 Description: OpenJDK Development Kit 11 (JDK) with Hotspot by AdoptOpenJDK
...
```

