### PR TITLE
Fix alternatives' priorities on RPM-based systems

### DIFF
--- a/linux/rpm/config/jdk-13-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-13-hotspot-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1131 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \

--- a/linux/rpm/config/jdk-13-hotspot/postinst.sh
+++ b/linux/rpm/config/jdk-13-hotspot/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1131 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -19,7 +19,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
                         --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1131 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \

--- a/linux/rpm/config/jdk-13-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-13-openj9-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1131 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \

--- a/linux/rpm/config/jdk-13-openj9/postinst.sh
+++ b/linux/rpm/config/jdk-13-openj9/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1131 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -19,7 +19,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
                         --slave /usr/share/man/man1/unpack200.1 unpack200.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/unpack200.1
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1131 \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \
                         --slave /usr/bin/javadoc javadoc {{ prefix }}/{{ jdkDirectoryName }}/bin/javadoc \

--- a/linux/rpm/config/jdk-14-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-14-hotspot-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1141 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \

--- a/linux/rpm/config/jdk-14-hotspot/postinst.sh
+++ b/linux/rpm/config/jdk-14-hotspot/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1141 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -15,7 +15,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1141 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \

--- a/linux/rpm/config/jdk-14-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-14-openj9-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1141 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \

--- a/linux/rpm/config/jdk-14-openj9/postinst.sh
+++ b/linux/rpm/config/jdk-14-openj9/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1141 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -15,7 +15,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1141 \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \
                         --slave /usr/bin/javadoc javadoc {{ prefix }}/{{ jdkDirectoryName }}/bin/javadoc \

--- a/linux/rpm/config/jdk-15-hotspot-jre/postinst.sh
+++ b/linux/rpm/config/jdk-15-hotspot-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1151 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \

--- a/linux/rpm/config/jdk-15-hotspot/postinst.sh
+++ b/linux/rpm/config/jdk-15-hotspot/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1151 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -15,7 +15,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1151 \
                         --slave /usr/bin/jaotc jaotc {{ prefix }}/{{ jdkDirectoryName }}/bin/jaotc \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \

--- a/linux/rpm/config/jdk-15-openj9-jre/postinst.sh
+++ b/linux/rpm/config/jdk-15-openj9-jre/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1151 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \

--- a/linux/rpm/config/jdk-15-openj9/postinst.sh
+++ b/linux/rpm/config/jdk-15-openj9/postinst.sh
@@ -1,5 +1,5 @@
 if [ $1 -ge 1 ] ; then
-    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1121 \
+    update-alternatives --install /usr/bin/java java {{ prefix }}/{{ jdkDirectoryName }}/bin/java 1151 \
                         --slave /usr/bin/jfr jfr {{ prefix }}/{{ jdkDirectoryName }}/bin/jfr \
                         --slave /usr/bin/jjs jjs {{ prefix }}/{{ jdkDirectoryName }}/bin/jjs \
                         --slave /usr/bin/jrunscript jrunscript {{ prefix }}/{{ jdkDirectoryName }}/bin/jrunscript \
@@ -15,7 +15,7 @@ if [ $1 -ge 1 ] ; then
                         --slave /usr/share/man/man1/rmid.1 rmid.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmid.1 \
                         --slave /usr/share/man/man1/rmiregistry.1 rmiregistry.1 {{ prefix }}/{{ jdkDirectoryName }}/man/man1/rmiregistry.1 \
 
-    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1121 \
+    update-alternatives --install /usr/bin/javac javac {{ prefix }}/{{ jdkDirectoryName }}/bin/javac 1151 \
                         --slave /usr/bin/jar jar {{ prefix }}/{{ jdkDirectoryName }}/bin/jar \
                         --slave /usr/bin/jarsigner jarsigner {{ prefix }}/{{ jdkDirectoryName }}/bin/jarsigner \
                         --slave /usr/bin/javadoc javadoc {{ prefix }}/{{ jdkDirectoryName }}/bin/javadoc \


### PR DESCRIPTION
JDK 12+ all had the same priority: 1121. As a result, installing a newer JDK would not replace the old one. The priorities are now as follows:

* 12: 1121
* 13: 1131
* 14: 1141
* 15: 1151