### PR TITLE
mac: Specify which keychain to unlock when signing mac builds

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -17,7 +17,7 @@
 set -eu
 
 if [ -f ~/.password ]; then
-  security unlock-keychain -p `cat ~/.password`
+  security unlock-keychain -p `cat ~/.password` login.keychain-db
 fi
 
 set +u


### PR DESCRIPTION
ref: 
https://github.com/AdoptOpenJDK/openjdk-build/pull/2064
https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1382

When unlocking a keychain, according to the security unlock-keychain syntax, if a keychain isn't specified, it will attempt to unlock the system keychain, which the Jenkins user isn't able to do. This can lead to the infra issue referenced above.