### PR TITLE
Replace SIGN_OPTION with SIGN_CERT

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -21,7 +21,7 @@ if [ -f ~/.password ]; then
 fi
 
 set +u
-SIGN_OPTION=
+SIGN_CERT=
 SIGN_CMD=
 if [ ! -z "$CERTIFICATE" ]; then
   SIGN_CMD="--sign"


### PR DESCRIPTION
I assume this was an oversight in the original authorship.
If CERTIFICATE is not defined the script will fail because
SIGN_CERT is unbound.

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>