### PR TITLE
Move quotes around SIGN_CERT into variable itself

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -21,11 +21,12 @@ if [ -f ~/.password ]; then
 fi
 
 set +u
-SIGN_CERT=
-SIGN_CMD=
-if [ ! -z "$CERTIFICATE" ]; then
+if [ -z "$CERTIFICATE" ]; then
+  SIGN_CMD=
+  SIGN_CERT=
+else
   SIGN_CMD="--sign"
-  SIGN_CERT="${CERTIFICATE}"
+  SIGN_CERT="'${CERTIFICATE}'"
 fi
 set -u
 
@@ -64,8 +65,8 @@ do tar -xf "$f";
   directory=$(ls -d jdk*)
   file=${f%%.tar.gz*}
 
-  echo running "./packagesbuild.sh ${SIGN_CMD} "${SIGN_CERT}" --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}"
-  ./packagesbuild.sh ${SIGN_CMD} "${SIGN_CERT}" --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}
+  echo running "./packagesbuild.sh ${SIGN_CMD} ${SIGN_CERT} --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}"
+  ./packagesbuild.sh ${SIGN_CMD} ${SIGN_CERT} --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}
 
   rm -rf ${directory}
   rm -rf ${f}

--- a/pkgbuild/packagesbuild.sh
+++ b/pkgbuild/packagesbuild.sh
@@ -173,7 +173,7 @@ cat OpenJDKPKG.pkgproj.template  \
   | sed -E "s~\\{directory\\}~$DIRECTORY~g" \
   | sed -E "s~\\{logo\\}~$LOGO~g" \
   >OpenJDKPKG.pkgproj ; \
-  
+
   cat Resources/en.lproj/welcome.html.tmpl  \
   | sed -E "s/\\{full_version\\}/$FULL_VERSION/g" \
   | sed -E "s/\\{directory\\}/$DIRECTORY/g" \
@@ -200,7 +200,7 @@ if [ ! -z "$NOTARIZE_OPTION" ]; then
   cd notarize
   npm install
   node notarize.js --appBundleId $IDENTIFIER --appPath ${OUTPUT_DIRECTORY}
-  if [ $? != 0 ]; then 
+  if [ $? != 0 ]; then
     exit 1
   fi
   # Validates that the app has been notarized


### PR DESCRIPTION
When CERTIFICATE is not used, the empty quotes around
SIGN_CERT in the packagebuild command will mess up the
input args. Moving the quotes into the variable will
remove them from the call when the variable doesn't get set.

Fixes #256
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>