### PR TITLE
Add full version number to PKG metadata

### DIFF
--- a/pkgbuild/OpenJDKPKG.pkgproj.template
+++ b/pkgbuild/OpenJDKPKG.pkgproj.template
@@ -164,7 +164,7 @@
         <key>USE_HFS+_COMPRESSION</key>
         <false/>
         <key>VERSION</key>
-        <string>1.0</string>
+        <string>{full-version}</string>
       </dict>
       <key>TYPE</key>
       <integer>0</integer>

--- a/pkgbuild/packagesbuild.sh
+++ b/pkgbuild/packagesbuild.sh
@@ -172,6 +172,7 @@ cat OpenJDKPKG.pkgproj.template  \
   | sed -E "s~\\{package-name\\}~$PACKAGE_NAME~g" \
   | sed -E "s~\\{directory\\}~$DIRECTORY~g" \
   | sed -E "s~\\{logo\\}~$LOGO~g" \
+  | sed -E "s~\\{full-version\\}~$FULL_VERSION~g" \
   >OpenJDKPKG.pkgproj ; \
   
   cat Resources/en.lproj/welcome.html.tmpl  \


### PR DESCRIPTION
During the migration to Packages, we stopped adding the full version number to the PKG metadata. Instead, it was hardcoded to 1.0.

Additionally, this PR fixes inconsistent capitalization of the file OpenJDKPkg.pkgproj.template which is an issue on Macs with a case-sensitive file system.

Fixes #263.