### PR TITLE
Ensure SIGN_CERT quoting is preserved

### DIFF
--- a/pkgbuild/create-installer-mac.sh
+++ b/pkgbuild/create-installer-mac.sh
@@ -26,7 +26,7 @@ if [ -z "$CERTIFICATE" ]; then
   SIGN_CERT=
 else
   SIGN_CMD="--sign"
-  SIGN_CERT="'${CERTIFICATE}'"
+  SIGN_CERT="${CERTIFICATE}"
 fi
 set -u
 
@@ -65,8 +65,13 @@ do tar -xf "$f";
   directory=$(ls -d jdk*)
   file=${f%%.tar.gz*}
 
-  echo running "./packagesbuild.sh ${SIGN_CMD} ${SIGN_CERT} --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}"
-  ./packagesbuild.sh ${SIGN_CMD} ${SIGN_CERT} --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}
+  if [ -z "$SIGN_CMD" ]; then
+    echo running "./packagesbuild.sh --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}"
+    ./packagesbuild.sh --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}
+  else
+    echo running "./packagesbuild.sh ${SIGN_CMD} "${SIGN_CERT}" --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}"
+    ./packagesbuild.sh ${SIGN_CMD} "${SIGN_CERT}" --major_version ${MAJOR_VERSION} --full_version ${FULL_VERSION} --input_directory ${directory} --output_directory ${file}.pkg --jvm ${JVM} --type ${TYPE}
+  fi
 
   rm -rf ${directory}
   rm -rf ${f}


### PR DESCRIPTION
PR https://github.com/AdoptOpenJDK/openjdk-installer/pull/257
moved the SIGN_CERT single quotes into the variable, but that then means they lose their meaning.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>