### PR TITLE
Depend on Freetype, Fontconfig, fonts

### DIFF
--- a/linux/deb/config/jdk-11-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-11-hotspot/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-11-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-11-openj9/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-15-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-15-hotspot-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-15-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-15-hotspot/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-15-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-15-openj9-jre/dependencies.txt
@@ -1,6 +1,10 @@
 ca-certificates
+fonts-dejavu
+java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-15-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-15-openj9/dependencies.txt
@@ -1,6 +1,9 @@
 ca-certificates
+fonts-dejavu
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-16-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-16-hotspot-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-16-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-16-hotspot/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-16-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-16-openj9-jre/dependencies.txt
@@ -1,6 +1,10 @@
 ca-certificates
+fonts-dejavu
+java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-16-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-16-openj9/dependencies.txt
@@ -1,6 +1,10 @@
 ca-certificates
+fonts-dejavu
+java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-hotspot-jre/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-hotspot/dependencies.txt
+++ b/linux/deb/config/jdk-8-hotspot/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9-jre/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/deb/config/jdk-8-openj9/dependencies.txt
+++ b/linux/deb/config/jdk-8-openj9/dependencies.txt
@@ -1,7 +1,10 @@
 ca-certificates
+fonts-dejavu
 java-common
 libasound2
 libc6
+libfreetype6
+libfontconfig1
 libx11-6
 libxext6
 libxi6

--- a/linux/rpm/config/jdk-11-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-11-hotspot-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-11-hotspot/dependencies.txt
+++ b/linux/rpm/config/jdk-11-hotspot/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-11-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-11-openj9-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-11-openj9/dependencies.txt
+++ b/linux/rpm/config/jdk-11-openj9/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-15-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-15-hotspot-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-15-hotspot/dependencies.txt
+++ b/linux/rpm/config/jdk-15-hotspot/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-15-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-15-openj9-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-15-openj9/dependencies.txt
+++ b/linux/rpm/config/jdk-15-openj9/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-16-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-16-hotspot-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-16-hotspot/dependencies.txt
+++ b/linux/rpm/config/jdk-16-hotspot/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-16-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-16-openj9-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-16-openj9/dependencies.txt
+++ b/linux/rpm/config/jdk-16-openj9/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -13,3 +14,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-hotspot-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-8-hotspot-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-hotspot/dependencies.txt
+++ b/linux/rpm/config/jdk-8-hotspot/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -14,3 +15,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 libthread_db.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-openj9-jre/dependencies.txt
+++ b/linux/rpm/config/jdk-8-openj9-jre/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -14,3 +15,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})

--- a/linux/rpm/config/jdk-8-openj9/dependencies.txt
+++ b/linux/rpm/config/jdk-8-openj9/dependencies.txt
@@ -1,6 +1,7 @@
 /bin/sh
 /usr/sbin/alternatives
 ca-certificates
+dejavu-sans-fonts
 libX11.so.6()({{rpmIsaBits}})
 libXext.so.6()({{rpmIsaBits}})
 libXi.so.6()({{rpmIsaBits}})
@@ -14,3 +15,5 @@ libm.so.6()({{rpmIsaBits}})
 libpthread.so.0()({{rpmIsaBits}})
 librt.so.1()({{rpmIsaBits}})
 libz.so.1()({{rpmIsaBits}})
+libfontconfig.so.1()({{rpmIsaBits}})
+libfreetype.so.6()({{rpmIsaBits}})


### PR DESCRIPTION
Required because we no longer bundle Freetype (see https://github.com/AdoptOpenJDK/openjdk-build/pull/2226). Fontconfig and fonts are required to get the font integration working.

Supersedes https://github.com/AdoptOpenJDK/openjdk-installer/pull/130.