### PR TITLE
Update supported distributions for Linux packages

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -183,17 +183,17 @@ By specifying all build properties (see above) building and uploading can be don
 
 All packages can be installed on Debian, Raspbian (armhf/arm64 only) and Ubuntu without further changes. They are available for amd64, s390x, ppc64el, armhf and arm64 unless otherwise noted. All major versions as well as JDKs and JREs can be installed side by side. JDKs and JREs have no dependencies on each other and are completely self-contained.
 
-| OpenJDK                  | Debian                               | Ubuntu                                                                      |
-|--------------------------|--------------------------------------|-----------------------------------------------------------------------------|
-| JDK 8 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 9 (Hotspot, OpenJ9)  | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 10 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 11 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 12 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 13 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 14 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 15 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
-| JDK 16 (Hotspot, OpenJ9) | 8 (jessie), 9 (stretch), 10 (buster) | 16.04 (xenial), 18.04 (bionic), 19.10 (eoan), 20.04 (focal), 20.10 (groovy) |
+| OpenJDK                  | Debian                                  | Ubuntu                                                                         |
+|--------------------------|-----------------------------------------|--------------------------------------------------------------------------------|
+| JDK 8 (Hotspot, OpenJ9)  | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 9 (Hotspot, OpenJ9)  | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 10 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 11 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 12 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 13 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 14 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 15 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
+| JDK 16 (Hotspot, OpenJ9) | 9 (stretch), 10 (buster), 11 (bullseye) | 16.04 (xenial), 18.04 (bionic), 20.04 (focal), 20.10 (groovy), 21.04 (hirsute) |
 
 * [Debian releases and support timeframe](https://wiki.debian.org/DebianReleases)
 * [Ubuntu releases and support timeframe](https://wiki.ubuntu.com/Releases)
@@ -204,15 +204,15 @@ All packages can be installed on Amazon Linux, CentOS, Fedora, Red Hat Enterpris
 
 | OpenJDK                  | Amazon  | CentOS  | Fedora     | RHEL    | OpenSUSE   | SLES   |
 |--------------------------|---------|---------|------------|---------|------------|--------|
-| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 13 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 14 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 15 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
-| JDK 16 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 31, 32, 33 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 8 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 9 (Hotspot, OpenJ9)  | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 10 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 11 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 12 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 13 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 14 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 15 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
+| JDK 16 (Hotspot, OpenJ9) | 1, 2    | 6, 7, 8 | 32, 33, 34 | 6, 7, 8 | 15.1, 15.2 | 12, 15 |
 
 * Amazon Linux releases and support timeframe: [Amazon Linux 1](https://aws.amazon.com/de/amazon-linux-ami/faqs/#how_long), [Amazon Linux 2](https://aws.amazon.com/de/amazon-linux-2/faqs/#Long_Term_Support)
 * [CentOS releases and support timeframe](https://wiki.centos.org/Download)

--- a/linux/deb/build.gradle
+++ b/linux/deb/build.gradle
@@ -49,24 +49,24 @@ tasks.register("uploadDebianPackage", UploadDebianPackage) {
     packageName = buildDebianPackage.getPackageName()
     architecture = buildDebianPackage.getArchitecture().debQualifier()
     releaseArchitecture amd64: [
-        debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "eoan", "focal", "groovy"]
+        debian: ["stretch", "buster", "bullseye"],
+        ubuntu: ["xenial", "bionic", "focal", "groovy", "hirsute"]
     ]
     releaseArchitecture s390x: [
-        debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "eoan", "focal", "groovy"]
+        debian: ["stretch", "buster", "bullseye"],
+        ubuntu: ["xenial", "bionic", "focal", "groovy", "hirsute"]
     ]
     releaseArchitecture ppc64el: [
-        debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "eoan", "focal", "groovy"]
+        debian: ["stretch", "buster", "bullseye"],
+        ubuntu: ["xenial", "bionic", "focal", "groovy", "hirsute"]
     ]
     releaseArchitecture armhf: [
-        debian  : ["jessie", "stretch", "buster"],
-        ubuntu  : ["xenial", "bionic", "eoan", "focal", "groovy"]
+        debian: ["stretch", "buster", "bullseye"],
+        ubuntu: ["xenial", "bionic", "focal", "groovy", "hirsute"]
     ]
     releaseArchitecture arm64: [
-        debian: ["jessie", "stretch", "buster"],
-        ubuntu: ["xenial", "bionic", "eoan", "focal", "groovy"]
+        debian: ["stretch", "buster", "bullseye"],
+        ubuntu: ["xenial", "bionic", "focal", "groovy", "hirsute"]
     ]
 }
 

--- a/linux/rpm/build.gradle
+++ b/linux/rpm/build.gradle
@@ -65,7 +65,7 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
         amazonlinux: ["1", "2"],
         centos     : ["6", "7", "8"],
         rhel       : ["6", "7", "8"],
-        fedora     : ["31", "32", "33"]
+        fedora     : ["32", "33", "34"]
     ]
     releaseArchitecture s390x: [
         centos: ["6", "7", "8"],
@@ -78,7 +78,11 @@ tasks.register("uploadRedHatRpmPackage", UploadRpmPackage) {
     releaseArchitecture aarch64: [
         amazonlinux: ["2"],
         centos     : ["6", "7", "8"],
-        rhel       : ["6", "7", "8"]
+        rhel       : ["6", "7", "8"],
+        fedora     : ["33", "34"]
+    ]
+    releaseArchitecture armhfp: [
+        fedora     : ["33", "34"]
     ]
 }
 


### PR DESCRIPTION
* Debian: Remove Jessie (EOL), add upcoming Bullseye.
* Ubuntu: Remove Eoan (EOL), add upcoming Hirsute.
* Fedora: Remove 31 (EOL), add upcoming 34, aarch64 and armhfp for >= 33.