### PR TITLE
Making IcedWeb-Tea optional for JDK 8u Windows MSI Installer

### DIFF
--- a/.github/workflows/wix.yml
+++ b/.github/workflows/wix.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Download Prebuilt JDK/JRE
         run: |
+          cd wix\SourceDir
           wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jdk_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
           wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jre_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
           ./CreateSourceFolder.AdoptOpenJDK.ps1

--- a/.github/workflows/wix.yml
+++ b/.github/workflows/wix.yml
@@ -2,63 +2,70 @@ name: Windows
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths:
       - .github/workflows/wix.yml
       - wix/**
 jobs:
   pkgbuild:
+    strategy:
+      matrix:
+        ICEDTEA_WEB_VERSION:
+          - "icedtea-web-1.8.3"
+          - ""
     name: wix
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
-    
-    - name: Install dependencies
-      run: |
-        choco install wget
+      - name: Install dependencies
+        run: |
+          choco install wget
 
-    - name: Setup environment variables
-      uses: allenevans/set-env@v2.0.0
-      with:
-        PRODUCT_MAJOR_VERSION: 8
-        PRODUCT_MINOR_VERSION: 0
-        PRODUCT_MAINTENANCE_VERSION: 265
-        PRODUCT_PATCH_VERSION: 0
-        PRODUCT_BUILD_NUMBER: "01"
-        MSI_PRODUCT_VERSION: 8.0.265.1
-        ARCH: x64
-        TAG: jdk8u265-b01
-        SUB_TAG: 8u265b01
-        JVM: hotspot
-        ICEDTEA_WEB_VERSION: icedtea-web-1.8.3
+      - name: Setup environment variables
+        uses: allenevans/set-env@v2.0.0
+        with:
+          PRODUCT_MAJOR_VERSION: 8
+          PRODUCT_MINOR_VERSION: 0
+          PRODUCT_MAINTENANCE_VERSION: 265
+          PRODUCT_PATCH_VERSION: 0
+          PRODUCT_BUILD_NUMBER: "01"
+          MSI_PRODUCT_VERSION: 8.0.265.1
+          ARCH: x64
+          TAG: jdk8u265-b01
+          SUB_TAG: 8u265b01
+          JVM: hotspot
 
-    - name: Download prebuilt binaries
-      run: |
-        cd wix\SourceDir
-        wget -q "https://github.com/AdoptOpenJDK/IcedTea-Web/releases/download/${{ env.ICEDTEA_WEB_VERSION }}/${{ env.ICEDTEA_WEB_VERSION }}.win.bin.zip"
-        unzip icedtea-web-*.win.bin.zip
-        rm icedtea-web-*.win.bin.zip
-        Remove-Item 'icedtea-web-image\share\doc' -Recurse
-        wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jdk_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
-        wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jre_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
-        ./CreateSourceFolder.AdoptOpenJDK.ps1
+      - name: Download IcedTea-Web
+        run: |
+          cd wix\SourceDir
+          wget -q "https://github.com/AdoptOpenJDK/IcedTea-Web/releases/download/${{ env.ICEDTEA_WEB_VERSION }}/${{ env.ICEDTEA_WEB_VERSION }}.win.bin.zip"
+          unzip icedtea-web-*.win.bin.zip
+          rm icedtea-web-*.win.bin.zip
+          Remove-Item 'icedtea-web-image\share\doc' -Recurse
+        if: ${{ matrix.ICEDTEA_WEB_VERSION != '' }}
 
-    - name: Create JDK Installer
-      run: |
-        cd wix
-        set PRODUCT_CATEGORY=jdk
-        call Build.OpenJDK_generic.cmd
-      shell: cmd
+      - name: Download Prebuilt JDK/JRE
+        run: |
+          wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jdk_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
+          wget -q "https://github.com/AdoptOpenJDK/openjdk${{ env.PRODUCT_MAJOR_VERSION }}-binaries/releases/download/${{ env.TAG }}/OpenJDK${{ env.PRODUCT_MAJOR_VERSION }}U-jre_${{ env.ARCH }}_windows_${{ env.JVM }}_${{ env.SUB_TAG }}.zip"
+          ./CreateSourceFolder.AdoptOpenJDK.ps1
 
-    - name: Create JRE Installer
-      run: |
-        cd wix
-        set PRODUCT_CATEGORY=jre
-        call Build.OpenJDK_generic.cmd
-      shell: cmd
+      - name: Create JDK Installer
+        run: |
+          cd wix
+          set PRODUCT_CATEGORY=jdk
+          call Build.OpenJDK_generic.cmd
+        shell: cmd
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: windows
-        path: wix/ReleaseDir/*.msi
+      - name: Create JRE Installer
+        run: |
+          cd wix
+          set PRODUCT_CATEGORY=jre
+          call Build.OpenJDK_generic.cmd
+        shell: cmd
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows
+          path: wix/ReleaseDir/*.msi

--- a/.github/workflows/wix.yml
+++ b/.github/workflows/wix.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Download IcedTea-Web
         run: |
           cd wix\SourceDir
-          wget -q "https://github.com/AdoptOpenJDK/IcedTea-Web/releases/download/${{ env.ICEDTEA_WEB_VERSION }}/${{ env.ICEDTEA_WEB_VERSION }}.win.bin.zip"
+          wget -q "https://github.com/AdoptOpenJDK/IcedTea-Web/releases/download/${{ matrix.ICEDTEA_WEB_VERSION }}/${{ matrix.ICEDTEA_WEB_VERSION }}.win.bin.zip"
           unzip icedtea-web-*.win.bin.zip
           rm icedtea-web-*.win.bin.zip
           Remove-Item 'icedtea-web-image\share\doc' -Recurse

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -213,7 +213,7 @@ FOR %%A IN (%ARCH%) DO (
     SET BUNDLE_ICEDTEAWEB=false
     IF !PLATFORM! == x64 (
         IF !PRODUCT_MAJOR_VERSION! == 8 (
-            IF EXIST %ICEDTEAWEB_DIR% (
+            IF EXIST !ICEDTEAWEB_DIR! (
                 ECHO IcedTeaWeb Directory Exist!
                 SET BUNDLE_ICEDTEAWEB=true
                 SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -241,7 +241,7 @@ FOR %%A IN (%ARCH%) DO (
 
     ECHO CANDLE
     @ECHO ON
-    "!WIX!bin\candle.exe" -arch !PLATFORM! Main-!OUTPUT_BASE_FILENAME!.wxs Files-!OUTPUT_BASE_FILENAME!.wxs !ITW_WXS! -ext WixUIExtension -ext WixUtilExtension -dProductSku="!PRODUCT_SKU!" -dProductMajorVersion="!PRODUCT_MAJOR_VERSION!" -dProductMinorVersion="!PRODUCT_MINOR_VERSION!" -dProductVersionString="!PRODUCT_SHORT_VERSION!" -dMSIProductVersion="!MSI_PRODUCT_VERSION!" -dProductId="!PRODUCT_ID!" -dProductUpgradeCode="!PRODUCT_UPGRADE_CODE!" -dReproDir="!REPRO_DIR!" -dSetupResourcesDir="!SETUP_RESOURCES_DIR!" -dCulture="!CULTURE!" -dJVM="!PACKAGE_TYPE!"
+    "!WIX!bin\candle.exe" -arch !PLATFORM! Main-!OUTPUT_BASE_FILENAME!.wxs Files-!OUTPUT_BASE_FILENAME!.wxs !ITW_WXS! -ext WixUIExtension -ext WixUtilExtension -dIcedTeaWebDir="!ICEDTEAWEB_DIR!" -dProductSku="!PRODUCT_SKU!" -dProductMajorVersion="!PRODUCT_MAJOR_VERSION!" -dProductMinorVersion="!PRODUCT_MINOR_VERSION!" -dProductVersionString="!PRODUCT_SHORT_VERSION!" -dMSIProductVersion="!MSI_PRODUCT_VERSION!" -dProductId="!PRODUCT_ID!" -dProductUpgradeCode="!PRODUCT_UPGRADE_CODE!" -dReproDir="!REPRO_DIR!" -dSetupResourcesDir="!SETUP_RESOURCES_DIR!" -dCulture="!CULTURE!" -dJVM="!PACKAGE_TYPE!"
     IF ERRORLEVEL 1 (
         ECHO Failed to preprocesses and compiles WiX source files into object files ^(.wixobj^)
         GOTO FAILED

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -95,7 +95,6 @@ REM
 REM Cultures: https://msdn.microsoft.com/de-de/library/ee825488(v=cs.20).aspx
 SET PRODUCT_SKU=OpenJDK
 SET PRODUCT_FULL_VERSION=%PRODUCT_MAJOR_VERSION%.%PRODUCT_MINOR_VERSION%.%PRODUCT_MAINTENANCE_VERSION%.%PRODUCT_PATCH_VERSION%.%PRODUCT_BUILD_NUMBER%
-SET ICEDTEAWEB_DIR=.\SourceDir\icedtea-web-image
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 SET PRODUCT_SHORT_VERSION=%PRODUCT_MAJOR_VERSION%u%PRODUCT_MAINTENANCE_VERSION%-b%PRODUCT_BUILD_NUMBER%
@@ -209,45 +208,55 @@ FOR %%A IN (%ARCH%) DO (
 
 	REM Build without extra Source Code feature
 
+    REM Set default variable
+    SET ICEDTEAWEB_DIR=.\SourceDir\icedtea-web-image
+    SET BUNDLE_ICEDTEAWEB=false
     IF !PLATFORM! == x64 (
         IF !PRODUCT_MAJOR_VERSION! == 8 (
-            SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"
-            SET ITW_WIXOBJ="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wixobj"
-            ECHO HEAT
-            "!WIX!bin\heat.exe" dir "!ICEDTEAWEB_DIR!" -out !ITW_WXS! -t "!SETUP_RESOURCES_DIR!\heat.icedteaweb.xslt" -gg -sfrag -scom -sreg -srd -ke -cg "IcedTeaWebFiles" -var var.IcedTeaWebDir -dr INSTALLDIR -platform !PLATFORM!
-            IF ERRORLEVEL 1 (
-                ECHO "Failed to generating Windows Installer XML Source files for IcedTea-Web (.wxs)"
-                GOTO FAILED
+            IF EXIST ICEDTEAWEB_DIR (
+                SET BUNDLE_ICEDTEAWEB=true
+                SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"
+                SET ITW_WIXOBJ="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wixobj"
+                ECHO HEAT
+                "!WIX!bin\heat.exe" dir "!ICEDTEAWEB_DIR!" -out !ITW_WXS! -t "!SETUP_RESOURCES_DIR!\heat.icedteaweb.xslt" -gg -sfrag -scom -sreg -srd -ke -cg "IcedTeaWebFiles" -var var.IcedTeaWebDir -dr INSTALLDIR -platform !PLATFORM!
+                IF ERRORLEVEL 1 (
+                    ECHO "Failed to generating Windows Installer XML Source files for IcedTea-Web (.wxs)"
+                    GOTO FAILED
+                )
             )
         )
     )
     
-		ECHO HEAT
-		@ECHO ON
-        "!WIX!bin\heat.exe" dir "!REPRO_DIR!" -out Files-!OUTPUT_BASE_FILENAME!.wxs -gg -sfrag -scom -sreg -srd -ke -cg "AppFiles" -var var.ProductMajorVersion -var var.ProductMinorVersion -var var.ProductVersionString -var var.MSIProductVersion -var var.ReproDir -dr INSTALLDIR -platform !PLATFORM!
-		IF ERRORLEVEL 1 (
-			ECHO Failed to generating Windows Installer XML Source files ^(.wxs^)
-		    GOTO FAILED
-		)
-		@ECHO OFF
+    ECHO HEAT
+    @ECHO ON
+    "!WIX!bin\heat.exe" dir "!REPRO_DIR!" -out Files-!OUTPUT_BASE_FILENAME!.wxs -gg -sfrag -scom -sreg -srd -ke -cg "AppFiles" -var var.ProductMajorVersion -var var.ProductMinorVersion -var var.ProductVersionString -var var.MSIProductVersion -var var.ReproDir -dr INSTALLDIR -platform !PLATFORM!
+    IF ERRORLEVEL 1 (
+        ECHO Failed to generating Windows Installer XML Source files ^(.wxs^)
+        GOTO FAILED
+    )
+    @ECHO OFF
 
-		ECHO CANDLE
-		@ECHO ON
-        "!WIX!bin\candle.exe" -arch !PLATFORM! Main-!OUTPUT_BASE_FILENAME!.wxs Files-!OUTPUT_BASE_FILENAME!.wxs !ITW_WXS! -ext WixUIExtension -ext WixUtilExtension -dIcedTeaWebDir="!ICEDTEAWEB_DIR!" -dProductSku="!PRODUCT_SKU!" -dProductMajorVersion="!PRODUCT_MAJOR_VERSION!" -dProductMinorVersion="!PRODUCT_MINOR_VERSION!" -dProductVersionString="!PRODUCT_SHORT_VERSION!" -dMSIProductVersion="!MSI_PRODUCT_VERSION!" -dProductId="!PRODUCT_ID!" -dProductUpgradeCode="!PRODUCT_UPGRADE_CODE!" -dReproDir="!REPRO_DIR!" -dSetupResourcesDir="!SETUP_RESOURCES_DIR!" -dCulture="!CULTURE!" -dJVM="!PACKAGE_TYPE!"
-		IF ERRORLEVEL 1 (
-		    ECHO Failed to preprocesses and compiles WiX source files into object files ^(.wixobj^)
-		    GOTO FAILED
-		)
-		@ECHO OFF
+    ECHO CANDLE
+    @ECHO ON
+    "!WIX!bin\candle.exe" -arch !PLATFORM! Main-!OUTPUT_BASE_FILENAME!.wxs Files-!OUTPUT_BASE_FILENAME!.wxs !ITW_WXS! -ext WixUIExtension -ext WixUtilExtension -dProductSku="!PRODUCT_SKU!" -dProductMajorVersion="!PRODUCT_MAJOR_VERSION!" -dProductMinorVersion="!PRODUCT_MINOR_VERSION!" -dProductVersionString="!PRODUCT_SHORT_VERSION!" -dMSIProductVersion="!MSI_PRODUCT_VERSION!" -dProductId="!PRODUCT_ID!" -dProductUpgradeCode="!PRODUCT_UPGRADE_CODE!" -dReproDir="!REPRO_DIR!" -dSetupResourcesDir="!SETUP_RESOURCES_DIR!" -dCulture="!CULTURE!" -dJVM="!PACKAGE_TYPE!"
+    IF ERRORLEVEL 1 (
+        ECHO Failed to preprocesses and compiles WiX source files into object files ^(.wixobj^)
+        GOTO FAILED
+    )
+    @ECHO OFF
 
-		ECHO LIGHT
-		@ECHO ON
-        "!WIX!bin\light.exe" Main-!OUTPUT_BASE_FILENAME!.wixobj Files-!OUTPUT_BASE_FILENAME!.wixobj !ITW_WIXOBJ! !MSI_VALIDATION_OPTION! -cc !CACHE_FOLDER! -ext WixUIExtension -ext WixUtilExtension -spdb -out "ReleaseDir\!OUTPUT_BASE_FILENAME!.msi" -loc "Lang\!PRODUCT_SKU!.Base.!CULTURE!.wxl" -loc "Lang\!PRODUCT_SKU!.!PACKAGE_TYPE!.!CULTURE!.wxl" -cultures:!CULTURE!
-		IF ERRORLEVEL 1 (
-		    ECHO Failed to links and binds one or more .wixobj files and creates a Windows Installer database ^(.msi or .msm^)
-		    GOTO FAILED
-		)
-		@ECHO OFF
+    ECHO LIGHT
+    @ECHO ON
+    "!WIX!bin\light.exe" Main-!OUTPUT_BASE_FILENAME!.wixobj Files-!OUTPUT_BASE_FILENAME!.wixobj !ITW_WIXOBJ! !MSI_VALIDATION_OPTION! -cc !CACHE_FOLDER! -ext WixUIExtension -ext WixUtilExtension -spdb -out "ReleaseDir\!OUTPUT_BASE_FILENAME!.msi" -loc "Lang\!PRODUCT_SKU!.Base.!CULTURE!.wxl" -loc "Lang\!PRODUCT_SKU!.!PACKAGE_TYPE!.!CULTURE!.wxl" -cultures:!CULTURE!
+    IF ERRORLEVEL 1 (
+        ECHO Failed to links and binds one or more .wixobj files and creates a Windows Installer database ^(.msi or .msm^)
+        GOTO FAILED
+    )
+    @ECHO OFF
+
+    REM Clean up variables
+    SET ICEDTEAWEB_DIR=
+    SET BUNDLE_ICEDTEAWEB=
 
     REM Generate setup translations
     FOR /F "tokens=1-2" %%L IN (Lang\LanguageList.config) do (
@@ -349,7 +358,6 @@ SET PRODUCT_VERSION=
 SET PLATFORM=
 SET FOLDER_PLATFORM=
 SET REPRO_DIR=
-SET ICEDTEAWEB_DIR=
 SET SETUP_RESOURCES_DIR=
 SET WIN_SDK_FULL_VERSION=
 SET WIN_SDK_MAJOR_VERSION=

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -213,7 +213,7 @@ FOR %%A IN (%ARCH%) DO (
     SET BUNDLE_ICEDTEAWEB=false
     IF !PLATFORM! == x64 (
         IF !PRODUCT_MAJOR_VERSION! == 8 (
-            IF EXIST %PRODUCT_MAJOR_VERSION% (
+            IF EXIST %ICEDTEAWEB_DIR% (
                 ECHO IcedTeaWeb Directory Exist!
                 SET BUNDLE_ICEDTEAWEB=true
                 SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -213,7 +213,8 @@ FOR %%A IN (%ARCH%) DO (
     SET BUNDLE_ICEDTEAWEB=false
     IF !PLATFORM! == x64 (
         IF !PRODUCT_MAJOR_VERSION! == 8 (
-            IF EXIST ICEDTEAWEB_DIR (
+            IF EXIST !PRODUCT_MAJOR_VERSION! (
+                ECHO IcedTeaWeb Directory Exist!
                 SET BUNDLE_ICEDTEAWEB=true
                 SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"
                 SET ITW_WIXOBJ="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wixobj"

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -224,6 +224,8 @@ FOR %%A IN (%ARCH%) DO (
                     ECHO "Failed to generating Windows Installer XML Source files for IcedTea-Web (.wxs)"
                     GOTO FAILED
                 )
+            ) ELSE (
+                ECHO IcedTeaWeb Directory Does Not Exist!
             )
         )
     )

--- a/wix/Build.OpenJDK_generic.cmd
+++ b/wix/Build.OpenJDK_generic.cmd
@@ -213,7 +213,7 @@ FOR %%A IN (%ARCH%) DO (
     SET BUNDLE_ICEDTEAWEB=false
     IF !PLATFORM! == x64 (
         IF !PRODUCT_MAJOR_VERSION! == 8 (
-            IF EXIST !PRODUCT_MAJOR_VERSION! (
+            IF EXIST %PRODUCT_MAJOR_VERSION% (
                 ECHO IcedTeaWeb Directory Exist!
                 SET BUNDLE_ICEDTEAWEB=true
                 SET ITW_WXS="IcedTeaWeb-!OUTPUT_BASE_FILENAME!.wxs"

--- a/wix/Main.hotspot.wxs
+++ b/wix/Main.hotspot.wxs
@@ -205,12 +205,14 @@
       </Feature>
       <?if $(env.Platform)=x64?>
         <?if $(env.PRODUCT_MAJOR_VERSION)=8?>
-          <Feature Id="FeatureIcedTeaWeb" ConfigurableDirectory="INSTALLDIR" Level="2" Title="!(loc.FeatureIcedTeaWebTitle)" Description="!(loc.FeatureIcedTeaWebDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="local">
-            <ComponentGroupRef Id="IcedTeaWebFiles" />
-            <Feature Id="FeatureJNLPFileRunWith" Level="3" Title="!(loc.FeatureJNLPFileRunWithTitle)" Description="!(loc.FeatureJNLPFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
-              <ComponentRef Id="SetJNLPFileRunWith" />
+          <?if $(env.BUNDLE_ICED_TEA_WEB)=true?>
+            <Feature Id="FeatureIcedTeaWeb" ConfigurableDirectory="INSTALLDIR" Level="2" Title="!(loc.FeatureIcedTeaWebTitle)" Description="!(loc.FeatureIcedTeaWebDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="local">
+              <ComponentGroupRef Id="IcedTeaWebFiles" />
+              <Feature Id="FeatureJNLPFileRunWith" Level="3" Title="!(loc.FeatureJNLPFileRunWithTitle)" Description="!(loc.FeatureJNLPFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
+                <ComponentRef Id="SetJNLPFileRunWith" />
+              </Feature>
             </Feature>
-          </Feature>
+          <?endif?>
         <?endif?>
       <?endif?>
     </Feature>

--- a/wix/Main.hotspot.wxs
+++ b/wix/Main.hotspot.wxs
@@ -151,20 +151,22 @@
       <!-- Add jnlp launch by double click -->
       <?if $(env.Platform)=x64?>
         <?if $(env.PRODUCT_MAJOR_VERSION)=8?>
-          <Component Id="SetJNLPFileRunWith" Guid="*">
-            <!--
-            https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
-                If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
-                If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
+          <?if $(env.BUNDLE_ICEDTEAWEB)=true?>
+            <Component Id="SetJNLPFileRunWith" Guid="*">
+              <!--
+              https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
+                  If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
+                  If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
 
-            HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jnlp\OpenWithProgids
-            is automatically created by Windows when running jnlp file for the first time
-            -->
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Value="AdoptOpenJDK.jnlpfile" KeyPath="yes" />
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Name="Content Type" Value="application/jnlp" KeyPath="no" />
+              HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jnlp\OpenWithProgids
+              is automatically created by Windows when running jnlp file for the first time
+              -->
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Value="AdoptOpenJDK.jnlpfile" KeyPath="yes" />
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Name="Content Type" Value="application/jnlp" KeyPath="no" />
 
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\AdoptOpenJDK.jnlpfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaws.exe&quot; -jnlp &quot;%1&quot; %*" KeyPath="no" />
-          </Component>
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\AdoptOpenJDK.jnlpfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaws.exe&quot; -jnlp &quot;%1&quot; %*" KeyPath="no" />
+            </Component>
+          <?endif?>
         <?endif?>
       <?endif?>
     </DirectoryRef>

--- a/wix/Main.hotspot.wxs
+++ b/wix/Main.hotspot.wxs
@@ -205,7 +205,7 @@
       </Feature>
       <?if $(env.Platform)=x64?>
         <?if $(env.PRODUCT_MAJOR_VERSION)=8?>
-          <?if $(env.BUNDLE_ICED_TEA_WEB)=true?>
+          <?if $(env.BUNDLE_ICEDTEAWEB)=true?>
             <Feature Id="FeatureIcedTeaWeb" ConfigurableDirectory="INSTALLDIR" Level="2" Title="!(loc.FeatureIcedTeaWebTitle)" Description="!(loc.FeatureIcedTeaWebDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="local">
               <ComponentGroupRef Id="IcedTeaWebFiles" />
               <Feature Id="FeatureJNLPFileRunWith" Level="3" Title="!(loc.FeatureJNLPFileRunWithTitle)" Description="!(loc.FeatureJNLPFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">

--- a/wix/Main.openj9.wxs
+++ b/wix/Main.openj9.wxs
@@ -151,20 +151,22 @@
       <!-- Add jnlp launch by double click -->
       <?if $(env.Platform)=x64?>
         <?if $(env.PRODUCT_MAJOR_VERSION)=8?>
-          <Component Id="SetJNLPFileRunWith" Guid="*">
-            <!--
-            https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
-                If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
-                If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
+          <?if $(env.BUNDLE_ICEDTEAWEB)=true?>
+            <Component Id="SetJNLPFileRunWith" Guid="*">
+              <!--
+              https://support.microsoft.com/en-us/help/256986/windows-registry-information-for-advanced-users
+                  If you write keys to a key under HKEY_CLASSES_ROOT, the system stores the information under HKEY_LOCAL_MACHINE\Software\Classes.
+                  If you write values to a key under HKEY_CLASSES_ROOT, and the key already exists under HKEY_CURRENT_USER\Software\Classes, the system will store the information there instead of under HKEY_LOCAL_MACHINE\Software\Classes.
 
-            HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jnlp\OpenWithProgids
-            is automatically created by Windows when running jnlp file for the first time
-            -->
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Value="AdoptOpenJDK.jnlpfile" KeyPath="yes" />
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Name="Content Type" Value="application/jnlp" KeyPath="no" />
+              HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.jnlp\OpenWithProgids
+              is automatically created by Windows when running jnlp file for the first time
+              -->
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Value="AdoptOpenJDK.jnlpfile" KeyPath="yes" />
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\.jnlp" Type="string" Name="Content Type" Value="application/jnlp" KeyPath="no" />
 
-            <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\AdoptOpenJDK.jnlpfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaws.exe&quot; -jnlp &quot;%1&quot; %*" KeyPath="no" />
-          </Component>
+              <RegistryValue Root="HKMU" Key="SOFTWARE\Classes\AdoptOpenJDK.jnlpfile\shell\open\command" Type="string" Value="&quot;[INSTALLDIR]bin\javaws.exe&quot; -jnlp &quot;%1&quot; %*" KeyPath="no" />
+            </Component>
+          <?endif?>
         <?endif?>
       <?endif?>
     </DirectoryRef>

--- a/wix/Main.openj9.wxs
+++ b/wix/Main.openj9.wxs
@@ -205,12 +205,14 @@
       </Feature>
       <?if $(env.Platform)=x64?>
         <?if $(env.PRODUCT_MAJOR_VERSION)=8?>
-          <Feature Id="FeatureIcedTeaWeb" ConfigurableDirectory="INSTALLDIR" Level="2" Title="!(loc.FeatureIcedTeaWebTitle)" Description="!(loc.FeatureIcedTeaWebDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="local">
-            <ComponentGroupRef Id="IcedTeaWebFiles" />
-            <Feature Id="FeatureJNLPFileRunWith" Level="3" Title="!(loc.FeatureJNLPFileRunWithTitle)" Description="!(loc.FeatureJNLPFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
-              <ComponentRef Id="SetJNLPFileRunWith" />
+          <?if $(env.BUNDLE_ICEDTEAWEB)=true?>
+            <Feature Id="FeatureIcedTeaWeb" ConfigurableDirectory="INSTALLDIR" Level="2" Title="!(loc.FeatureIcedTeaWebTitle)" Description="!(loc.FeatureIcedTeaWebDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="local">
+              <ComponentGroupRef Id="IcedTeaWebFiles" />
+              <Feature Id="FeatureJNLPFileRunWith" Level="3" Title="!(loc.FeatureJNLPFileRunWithTitle)" Description="!(loc.FeatureJNLPFileRunWithDescription)" Absent="allow" AllowAdvertise="no" InstallDefault="followParent">
+                <ComponentRef Id="SetJNLPFileRunWith" />
+              </Feature>
             </Feature>
-          </Feature>
+          <?endif?>
         <?endif?>
       <?endif?>
     </Feature>


### PR DESCRIPTION
1. Check whether `ICEDTEAWEB_DIR` exists before creating the jdk8u MSI installer.
2. Update GitHub action to test this change & Refactor the code format.